### PR TITLE
Enable support for a full year of 36 reacquiring weekly sessions

### DIFF
--- a/add_form.php
+++ b/add_form.php
@@ -135,7 +135,7 @@ class mod_attendance_add_form extends moodleform {
         $mform->addGroup($sdays, 'sdays', get_string('sessiondays', 'attendance'), array('&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'), true);
         $mform->disabledIf('sdays', 'addmultiply', 'notchecked');
 
-        $period = array(1=>1, 2, 3, 4, 5, 6, 7, 8);
+        $period = array(1=>1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36);
         $periodgroup = array();
         $periodgroup[] =& $mform->createElement('select', 'period', '', $period, false, true);
         $periodgroup[] =& $mform->createElement('static', 'perioddesc', '', get_string('week', 'attendance'));


### PR DESCRIPTION
Hi Dan,

Teachers asked my to extend the available reacquiring weekly sessions in the form. Hope it is agreeable by you.

It now support a full year (two academic semesters) of 36 weeks.

What do you think?
