### PR TITLE
On upgrade, update grade items to 'attendance'

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -1432,6 +1432,12 @@ function attforblock_upgrade() {
     $module->name = 'attendance';
     $DB->update_record('modules', $module);
 
+    // Now convert grade items to 'attendance'
+    $sql = "UPDATE {grade_items}
+            SET itemmodule = ?
+            WHERE itemmodule = ?";
+    $DB->execute($sql, array('attendance', 'attforblock'));
+
     // Clear cache for courses with attendances.
     $attendances = $DB->get_recordset('attendance', array(), '', 'course');
     foreach ($attendances as $attendance) {


### PR DESCRIPTION
This causes a minor error after upgrade:

Notice: Invalid get_string() identifier: 'modulename' or component 'attforblock'. Perhaps you are missing $string['modulename'] = ''; in mod/attforblock/lang/en/attforblock.php? \* line 6982 of /lib/moodlelib.php: call to debugging() \* line 7682 of /lib/moodlelib.php: call to core_string_manager->get_string() \* line 1201 of /grade/lib.php: call to get_string() \* line 1249 of /grade/lib.php: call to grade_structure->get_element_icon() \* line 319 of /grade/report/user/lib.php: call to grade_structure->get_element_header() \* line 563 of /grade/report/user/lib.php: call to grade_report_user->fill_table_recursive() \* line 305 of /grade/report/user/lib.php: call to grade_report_user->fill_table_recursive() \* line 927 of /grade/report/user/lib.php: call to grade_report_user->fill_table() \* line 129 of /course/user.php: call to grade_report_user_profilereport() in /var/www/htdocs/moodle/lib/weblib.php on line 2769
Invalid get_string() identifier: 'modulename' or component 'attforblock'. Perhaps you are missing $string['modulename'] = ''; in mod/attforblock/lang/en/attforblock.php?
line 6982 of /lib/moodlelib.php: call to debugging()
line 7682 of /lib/moodlelib.php: call to core_string_manager->get_string()
line 1201 of /grade/lib.php: call to get_string()
line 1249 of /grade/lib.php: call to grade_structure->get_element_icon()
line 319 of /grade/report/user/lib.php: call to grade_structure->get_element_header()
line 563 of /grade/report/user/lib.php: call to grade_report_user->fill_table_recursive()
line 305 of /grade/report/user/lib.php: call to grade_report_user->fill_table_recursive()
line 927 of /grade/report/user/lib.php: call to grade_report_user->fill_table()
line 129 of /course/user.php: call to grade_report_user_profilereport()

Requires attforblock grade column in the gradebook before upgrade. ie: mark a session, then upgrade.
