### PR TITLE
New feature for Statuses

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -70,6 +70,7 @@
         <FIELD NAME="grade" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="visible" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
         <FIELD NAME="deleted" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="calc_total" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Consider absence as justified or not"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="Primary key for attendance_settings"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -83,6 +83,19 @@ function xmldb_attendance_upgrade($oldversion=0) {
         $DB->delete_records_select('capabilities', 'component = ?', array('mod_attforblock'));
 
         upgrade_plugin_savepoint($result, 2013082902, 'mod', 'attendance');
+    } else if( $oldversion<2014072101 ) {
+
+        $table = new xmldb_table('attendance_statuses');
+        // ADD NEW FIELDS TO 'attendance_status' table
+
+        $field = new xmldb_field('calc_total');
+        $field->set_attributes(XMLDB_TYPE_INTEGER, '1', XMLDB_UNSIGNED, XMLDB_NOTNULL, null, '0');
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Certificate savepoint reached.
+        upgrade_mod_savepoint(true, 2014072101, 'attendance');
     }
 
     return $result;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -83,7 +83,10 @@ function xmldb_attendance_upgrade($oldversion=0) {
         $DB->delete_records_select('capabilities', 'component = ?', array('mod_attforblock'));
 
         upgrade_plugin_savepoint($result, 2013082902, 'mod', 'attendance');
-    } else if( $oldversion<2014072101 ) {
+
+    }
+
+    if( $oldversion<2014072101 ) {
 
         $table = new xmldb_table('attendance_statuses');
         // ADD NEW FIELDS TO 'attendance_status' table
@@ -96,6 +99,7 @@ function xmldb_attendance_upgrade($oldversion=0) {
 
         // Certificate savepoint reached.
         upgrade_mod_savepoint(true, 2014072101, 'attendance');
+        
     }
 
     return $result;

--- a/preferences.php
+++ b/preferences.php
@@ -53,8 +53,9 @@ switch ($att->pageparams->action) {
         $newacronym         = optional_param('newacronym', null, PARAM_TEXT);
         $newdescription     = optional_param('newdescription', null, PARAM_TEXT);
         $newgrade           = optional_param('newgrade', 0, PARAM_INT);
+        $newcalc_total      = optional_param('newcalc_total', false, PARAM_BOOL);
 
-        $att->add_status($newacronym, $newdescription, $newgrade);
+        $att->add_status($newacronym, $newdescription, $newgrade, $newcalc_total);
         break;
     case att_preferences_page_params::ACTION_DELETE:
         if (att_has_logs_for_status($att->pageparams->statusid)) {
@@ -80,18 +81,19 @@ switch ($att->pageparams->action) {
         echo $OUTPUT->footer();
         exit;
     case att_preferences_page_params::ACTION_HIDE:
-        $att->update_status($att->pageparams->statusid, null, null, null, 0);
+        $att->update_status($att->pageparams->statusid, null, null, null, null, 0);
         break;
     case att_preferences_page_params::ACTION_SHOW:
-        $att->update_status($att->pageparams->statusid, null, null, null, 1);
+        $att->update_status($att->pageparams->statusid, null, null, null, null, 1);
         break;
     case att_preferences_page_params::ACTION_SAVE:
         $acronym        = required_param_array('acronym', PARAM_MULTILANG);
         $description    = required_param_array('description', PARAM_MULTILANG);
         $grade          = required_param_array('grade', PARAM_INT);
+        $calc_total     = optional_param_array('calc_total', false, PARAM_BOOL);
 
         foreach ($acronym as $id => $v) {
-            $att->update_status($id, $acronym[$id], $description[$id], $grade[$id], null);
+            $att->update_status($id, $acronym[$id], $description[$id], $grade[$id], $calc_total[$id], null);
         }
         if ($att->grade > 0) {
             att_update_all_users_grades($att->id, $att->course, $att->context, $cm);

--- a/renderer.php
+++ b/renderer.php
@@ -911,6 +911,7 @@ class mod_attendance_renderer extends plugin_renderer_base {
                              get_string('acronym', 'attendance'),
                              get_string('description'),
                              get_string('grade'),
+                             get_string('calc_total','attendance'),
                              get_string('action'));
         $table->align = array('center', 'center', 'center', 'center', 'center', 'center');
 
@@ -920,6 +921,7 @@ class mod_attendance_renderer extends plugin_renderer_base {
             $table->data[$i][] = $this->construct_text_input('acronym['.$st->id.']', 2, 2, $st->acronym);
             $table->data[$i][] = $this->construct_text_input('description['.$st->id.']', 30, 30, $st->description);
             $table->data[$i][] = $this->construct_text_input('grade['.$st->id.']', 4, 4, $st->grade);
+            $table->data[$i][] = $this->construct_check_box('calc_total['.$st->id.']',$st->calc_total);
             $table->data[$i][] = $this->construct_preferences_actions_icons($st, $prefdata);
 
             $i++;
@@ -929,6 +931,7 @@ class mod_attendance_renderer extends plugin_renderer_base {
         $table->data[$i][] = $this->construct_text_input('newacronym', 2, 2);
         $table->data[$i][] = $this->construct_text_input('newdescription', 30, 30);
         $table->data[$i][] = $this->construct_text_input('newgrade', 4, 4);
+        $table->data[$i][] = $this->construct_check_box('newcalc_total', 0);
         $table->data[$i][] = $this->construct_preferences_button(get_string('add', 'attendance'),
                                                                  att_preferences_page_params::ACTION_ADD);
 
@@ -990,6 +993,15 @@ class mod_attendance_renderer extends plugin_renderer_base {
                 'type'      => 'submit',
                 'value'     => $text,
                 'onclick'   => 'M.mod_attendance.set_preferences_action('.$action.')');
+        return html_writer::empty_tag('input', $attributes);
+    }
+
+    private function construct_check_box($name, $text) {
+        $attributes = array(
+                'name'      => $name,
+                'type'      => 'checkbox' );
+        if( $text==1 )
+            $attributes["checked"] = "checked";
         return html_writer::empty_tag('input', $attributes);
     }
 


### PR DESCRIPTION
New feature for statuses. It gives the possibility to specify (with a checkbox in add/edit statuses page) for a status, e.g., saved as “Justified”, to not combine to the total of presences/absences. This feature is related to the percentage one. If a student must have a minimum percentage of 60% to access final exam, and in a total of six lessons his report is P-A-P-J-P-A, if status J is like A, without the new feature, the percentage would be 3P/6 = 50%, in the other case (with feature and Grade set to 0) would be 3P/5 = 60%.
In addition, this feature could be useful also to gain Grades in extra lessons. If this feature is selected for a status (E) with e.g. Grade set to 1, attending a lesson with status E means make own percentage grows.