### PR TITLE
events: Pass the actual dbrecord as snapshot for report_viewed event

### DIFF
--- a/report.php
+++ b/report.php
@@ -38,12 +38,12 @@ $pageparams->perpage    = get_config('attendance', 'resultsperpage');
 
 $cm             = get_coursemodule_from_id('attendance', $id, 0, false, MUST_EXIST);
 $course         = $DB->get_record('course', array('id' => $cm->course), '*', MUST_EXIST);
-$att            = $DB->get_record('attendance', array('id' => $cm->instance), '*', MUST_EXIST);
+$attrecord = $DB->get_record('attendance', array('id' => $cm->instance), '*', MUST_EXIST);
 
 require_login($course, true, $cm);
 
 $pageparams->init($cm);
-$att = new attendance($att, $cm, $course, $PAGE->context, $pageparams);
+$att = new attendance($attrecord, $cm, $course, $PAGE->context, $pageparams);
 
 $att->perm->require_view_reports_capability();
 
@@ -67,7 +67,7 @@ $event = \mod_attendance\event\report_viewed::create(array(
     'other' => array()
 ));
 $event->add_record_snapshot('course_modules', $cm);
-$event->add_record_snapshot('attendance', $att);
+$event->add_record_snapshot('attendance', $attrecord);
 $event->trigger();
 
 // Output starts here.


### PR DESCRIPTION
add_record_snapshot emits debugging warnings when the object passed is not a db record for the specified table.
