### PR TITLE
Fix upgrade process for studentscanmark field.

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -34,18 +34,6 @@ function xmldb_attendance_upgrade($oldversion=0) {
 
     $result = true;
 
-    if ($oldversion < 2013082901) {
-        $table = new xmldb_table('attendance_sessions');
-
-        $field = new xmldb_field('studentscanmark');
-        $field->set_attributes(XMLDB_TYPE_INTEGER, '1', XMLDB_UNSIGNED, XMLDB_NOTNULL, null, '0');
-        if (!$dbman->field_exists($table, $field)) {
-            $dbman->add_field($table, $field);
-        }
-        
-        upgrade_mod_savepoint($result, 2013082901, 'attendance');
-    }
-
     if ($oldversion < 2013082902) {
         // Replace values that reference old module "attforblock" to "attendance".
         $sql = "UPDATE {grade_items}
@@ -83,6 +71,18 @@ function xmldb_attendance_upgrade($oldversion=0) {
         $DB->delete_records_select('capabilities', 'component = ?', array('mod_attforblock'));
 
         upgrade_plugin_savepoint($result, 2013082902, 'mod', 'attendance');
+    }
+
+    if ($oldversion < 2014022802) {
+        $table = new xmldb_table('attendance_sessions');
+
+        $field = new xmldb_field('studentscanmark');
+        $field->set_attributes(XMLDB_TYPE_INTEGER, '1', XMLDB_UNSIGNED, XMLDB_NOTNULL, null, '0');
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+        
+        upgrade_mod_savepoint($result, 2014022802, 'attendance');
     }
 
     return $result;


### PR DESCRIPTION
On https://moodle.org/plugins/pluginversions.php?plugin=mod_attendance the previous version for a moodle 2.6 install is [2014022801](https://moodle.org/plugins/download.php/5996/mod_attendance_moodle26_2014022801.zip), and that version does _not_ have a "studentscanmark" field, but 2014022802 does.  However, upgrade.php is checking for 2013082901 to add the studentscanmark field. This means that this upgrade path breaks things.
