### PR TITLE
MDL26 - Check if there is a manual enrolment with no expiry date

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -1031,7 +1031,7 @@ class attendance {
 
             // CONTRIB-4868
             $mintime = 'MIN(CASE WHEN (ue.timestart > :zerotime) THEN ue.timestart ELSE ue.timecreated END)';
-            $maxtime = 'MAX(ue.timeend)';
+            $maxtime = 'CASE WHEN MIN(ue.timeend) = 0 THEN 0 ELSE MAX(ue.timeend) END';
 
             // CONTRIB-3549
             $sql = "SELECT ue.userid, ue.status,


### PR DESCRIPTION
Fix for issue #81 (MOODLE_24-26_STABLE branch)

Expired self enrolments prevent attendance taking when active manual enrolments exist.

Include manual enrolments with no expiry date in get_users() method of attendance class. This will prevent an expired enrolment from overriding and active enrolment with no expiry date.