### PR TITLE
The code for Moodle 2.8 should not allow installation on Moodle 2.7

### DIFF
--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
  */
 
 $plugin->version  = 2015040503;
-$plugin->requires = 2014042900;
+$plugin->requires = 2014111007;
 $plugin->release = '2.9.1.1';
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->cron     = 0;


### PR DESCRIPTION
Fix #124 for the 2.8 branch to prevent installation on earlier Moodle versions.