### PR TITLE
Adding gradepass feature using standard functions

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -51,8 +51,8 @@ class mod_attendance_mod_form extends moodleform_mod {
         $mform->addRule('name', null, 'required', null, 'client');
         $mform->setDefault('name', get_string('modulename', 'attendance'));
 
-        $mform->addElement('modgrade', 'grade', get_string('grade'));
-        $mform->setDefault('grade', 100);
+        // Grade settings.
+        $this->standard_grading_coursemodule_elements();
 
         $this->standard_coursemodule_elements(true);
         $this->add_action_buttons();


### PR DESCRIPTION
Using the Moodle core standard_grading_coursemodule_elements() function to show the grade section in the attendance module settings.
Starting from version 2.9.x this includes the gradepass feature, that permits to show, in gradebook report, the percentage of attendance in green if the grade is greater/equal than the gradepass value, otherwise is shown in red.