### PR TITLE
Returns all users and their lowest status in a course.

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -977,7 +977,7 @@ class attendance {
             $maxtime = 'CASE WHEN MIN(ue.timeend) = 0 THEN 0 ELSE MAX(ue.timeend) END';
 
             // CONTRIB-3549
-            $sql = "SELECT ue.userid, ue.status,
+            $sql = "SELECT ue.userid, MIN(ue.status) as status,
                            $mintime AS mintime,
                            $maxtime AS maxtime
                       FROM {user_enrolments} ue
@@ -985,7 +985,7 @@ class attendance {
                      WHERE ue.userid $sql
                            AND e.status = :estatus
                            AND e.courseid = :courseid
-                  GROUP BY ue.userid, ue.status";
+                  GROUP BY ue.userid";
             $params += array('zerotime'=>0, 'estatus'=>ENROL_INSTANCE_ENABLED, 'courseid'=>$this->course->id);
             $enrolments = $DB->get_records_sql($sql, $params);
 


### PR DESCRIPTION
This will fix 2 issues.  The first, if a user has a suspended enrollment
in child course A, the active enrollment in child course B will be
honored over the suspended enrollment.  Also in this scenerio, the user
with multiple enrollments was causing a duplicate userid error to be
generated.