### PR TITLE
Fix #155: Hiding statuses removes them from Settings

### DIFF
--- a/preferences.php
+++ b/preferences.php
@@ -100,9 +100,9 @@ switch ($att->pageparams->action) {
         echo $OUTPUT->footer();
         exit;
     case att_preferences_page_params::ACTION_HIDE:
-        $statuses = $att->get_statuses();
         $status = $statuses[$att->pageparams->statusid];
         $att->update_status($status, null, null, null, 0);
+        $statuses = $att->get_statuses(false);
         break;
     case att_preferences_page_params::ACTION_SHOW:
         $statuses = $att->get_statuses(false);


### PR DESCRIPTION
This just happened temporarily when you hid something.  If you come back to the settings page the variables would still be there.