### PR TITLE
Fix issue #165 - Alert if session date is prior to the course start date

### DIFF
--- a/add_form.php
+++ b/add_form.php
@@ -165,6 +165,12 @@ class mod_attendance_add_form extends moodleform {
                            null, array('maxfiles'=>EDITOR_UNLIMITED_FILES, 'noclean'=>true, 'context'=>$modcontext));
         $mform->setType('sdescription', PARAM_RAW);
 
+        $mform->addElement('hidden', 'coursestartdate', $course->startdate);
+        $mform->setType('coursestartdate', PARAM_INT);
+
+        $mform->addElement('hidden', 'previoussessiondate', 0);
+        $mform->setType('previoussessiondate', PARAM_INT);
+
         $submit_string = get_string('addsession', 'attendance');
         $this->add_action_buttons(false, $submit_string);
     }
@@ -198,6 +204,12 @@ class mod_attendance_add_form extends moodleform {
         if ($addmulti && ceil(($data['sessionenddate'] - $data['sessiondate']) / YEARSECS) > 1) {
             $errors['sessionenddate'] = get_string('timeahead', 'attendance');
         }
+
+        if ($data['sessiondate'] < $data['coursestartdate'] && $data['sessiondate'] != $data['previoussessiondate']) {
+            $errors['sessiondate'] = get_string('priorto', 'attendance', userdate($data['coursestartdate'], get_string('strftimedmy', 'attendance')));
+            $this->_form->setConstant('previoussessiondate', $data['sessiondate']);
+        }
+
         return $errors;
     }
 

--- a/lang/en/attendance.php
+++ b/lang/en/attendance.php
@@ -310,3 +310,4 @@ $string['confirmdeletehiddensessions'] = 'Are you sure you want to delete {$a->c
 $string['hiddensessionsdeleted'] = 'All hidden sessions were delete';
 
 $string['timeahead'] = 'Multiple sessions that exceed one year cannot be created, please adjust the start and end dates.';
+$string['priorto'] = 'The session date is prior to the course start date ({$a}) so that the new sessions scheduled before this date will be hidden (not accessible). You can change the course start date at any time (see course settings) in order to have access to earlier sessions.<br><br>Please change the session date or just click the "Add session" button again to confirm?';


### PR DESCRIPTION
Please take a look at this approach to address the issue #165. It is much simpler than that using JavaScript.