### PR TITLE
Expired enrolments can prevent student self-attendance

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -1042,7 +1042,7 @@ class attendance {
 
         // CONTRIB-4868
         $mintime = 'MIN(CASE WHEN (ue.timestart > :zerotime) THEN ue.timestart ELSE ue.timecreated END)';
-        $maxtime = 'MAX(ue.timeend)';
+        $maxtime = 'CASE WHEN MIN(ue.timeend) = 0 THEN 0 ELSE MAX(ue.timeend) END';
 
         $sql = "SELECT ue.userid, ue.status,
                        $mintime AS mintime,


### PR DESCRIPTION
...even when their is another enrolemnt that means they are still active on the course.

This fixes issue #178 and is similar to issue #81

This fixes the issue on the master branch