### PR TITLE
Taken sessions by acronym

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -12,6 +12,11 @@
     padding: 5px;
 }
 
+.path-mod-attendance .attdetailcheckbox {
+    margin-left: 2px;
+    margin-right: 2px;
+}
+
 .path-mod-attendance .attfiltercontrols {
     margin-bottom: 10px;
     margin-left:auto;
@@ -163,14 +168,6 @@
     color: red;
 }
 
-.path-mod-attendance .summaryreport .c5 {
-    background-color: #EAEAEA;
-}
-
-.path-mod-attendance .summaryreport .c6 {
-    background-color: #EAEAEA;
-}
-
-.path-mod-attendance .summaryreport .c7 {
+.path-mod-attendance .columncontrast {
     background-color: #EAEAEA;
 }

--- a/styles.css
+++ b/styles.css
@@ -12,11 +12,6 @@
     padding: 5px;
 }
 
-.path-mod-attendance .attdetailcheckbox {
-    margin-left: 2px;
-    margin-right: 2px;
-}
-
 .path-mod-attendance .attfiltercontrols {
     margin-bottom: 10px;
     margin-left:auto;


### PR DESCRIPTION
Code proposal for # 225.

I don't know what the users really do with this data. Thus, the best choice seems to be including them in all report tabs. This is the simpler way to implement this too.

In the future would be nice if there is a way the user could  select what data he would see (sessions details, sessions by acronym, summary) or just implement #213.