### PR TITLE
Moodle 30 - Global Search issue with Database Schema

### DIFF
--- a/classes/structure.php
+++ b/classes/structure.php
@@ -50,6 +50,15 @@ class mod_attendance_structure {
     /** @var float number (10, 5) unsigned, the maximum grade for attendance */
     public $grade;
 
+    /** @var int when was this module last modified */
+    public $timemodified;
+
+    /** @var string required field for activity modules and searching */
+    public $intro;
+
+    /** @var int format of the intro (see above) */
+    public $introformat;
+
     /** current page parameters */
     public $pageparams;
 

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/attendance/db" VERSION="20130704" COMMENT="XMLDB file for Moodle mod/attendance"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
->
+<XMLDB PATH="mod/attendance/db" VERSION="20170307" COMMENT="XMLDB file for Moodle mod/attendance"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
+        >
   <TABLES>
     <TABLE NAME="attendance" COMMENT="Attendance module table">
       <FIELDS>
@@ -10,6 +10,9 @@
         <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="grade" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="100" SEQUENCE="false" COMMENT="This is maximum grade for instance"/>
+        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="The time the settings for this attendance instance were last modified."/>
+        <FIELD NAME="intro" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="This field is a requirement for activity modules."/>
+        <FIELD NAME="introformat" TYPE="int" LENGTH="4" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="This field is a requirement for activity modules."/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="Primary key for attendance"/>
@@ -30,7 +33,7 @@
         <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="description" TYPE="text" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="descriptionformat" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="studentscanmark" TYPE="int" LENGTH="1" NOTNULL="true" UNSIGNED="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="studentscanmark" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="statusset" TYPE="int" LENGTH="5" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Which set of statuses to use"/>
       </FIELDS>
       <KEYS>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -158,5 +158,34 @@ function xmldb_attendance_upgrade($oldversion=0) {
         upgrade_mod_savepoint(true, 2015040503, 'attendance');
     }
 
+    if ($oldversion < 2016031502) {
+
+        // Define field timemodified to be added to attendance.
+        $table = new xmldb_table('attendance');
+        $field = new xmldb_field('timemodified', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0', 'grade');
+
+        // Conditionally launch add field timemodified.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field timemodified to be added to attendance.
+        $table = new xmldb_table('attendance');
+
+        $fields = [];
+        $fields[] = new xmldb_field('intro', XMLDB_TYPE_TEXT, null, null, null, null, null, 'timemodified');
+        $fields[] = new xmldb_field('introformat', XMLDB_TYPE_INTEGER, '4', null, XMLDB_NOTNULL, null, 0, 'intro');
+
+        // Conditionally launch add field.
+        foreach ($fields as $field) {
+            if (!$dbman->field_exists($table, $field)) {
+                $dbman->add_field($table, $field);
+            }
+        }
+
+        // Attendance savepoint reached.
+        upgrade_mod_savepoint(true, 2016031502, 'attendance');
+    }
+
     return $result;
 }

--- a/version.php
+++ b/version.php
@@ -22,9 +22,9 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$plugin->version  = 2016031501;
+$plugin->version  = 2016031502;
 $plugin->requires = 2015051100;
-$plugin->release = '3.1.0.1';
+$plugin->release = '3.1.0.2';
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->cron     = 0;
 $plugin->component = 'mod_attendance';


### PR DESCRIPTION
Moodle 30 has no search plugins, so the global search is not a problem.

As stated in #243 the schema still diverges from the documentation.

The following tests were performed to ensure the files are consistent (no warnings with full debugging messages):

* Performed an upgrade after installing the previous version from this fix.
* Performed an uninstall from Moodle GUI.
* Performed a fresh install of the attendance mod (not using upgrade).

@danmarsden please let me know if I need to change something

Cheers,

Daniel