### PR TITLE
Make display of user 'extrafields' optional in report.

### DIFF
--- a/backup/moodle2/backup_attendance_stepslib.php
+++ b/backup/moodle2/backup_attendance_stepslib.php
@@ -44,7 +44,7 @@ class backup_attendance_activity_structure_step extends backup_activity_structur
 
         // XML nodes declaration - non-user data.
         $attendance = new backup_nested_element('attendance', array('id'), array(
-            'name', 'intro', 'introformat', 'grade', 'showsessiondetails', 'sessiondetailspos', 'subnet'));
+            'name', 'intro', 'introformat', 'grade', 'showextrauserdetails', 'showsessiondetails', 'sessiondetailspos', 'subnet'));
 
         $statuses = new backup_nested_element('statuses');
         $status  = new backup_nested_element('status', array('id'), array(

--- a/classes/report_page_params.php
+++ b/classes/report_page_params.php
@@ -35,6 +35,8 @@ class mod_attendance_report_page_params extends mod_attendance_page_with_filter_
     /** @var int */
     public $sort;
     /** @var int */
+    public $showextrauserdetails;
+    /** @var int */
     public $showsessiondetails;
     /** @var int */
     public $sessiondetailspos;
@@ -71,6 +73,10 @@ class mod_attendance_report_page_params extends mod_attendance_page_with_filter_
 
         if ($this->sort != ATT_SORT_DEFAULT) {
             $params['sort'] = $this->sort;
+        }
+
+        if (empty($this->showextrauserdetails)) {
+            $params['showextrauserdetails'] = 0;
         }
 
         if (empty($this->showsessiondetails)) {

--- a/classes/structure.php
+++ b/classes/structure.php
@@ -76,6 +76,9 @@ class mod_attendance_structure {
     /** @var boolean flag set when automarking is complete. */
     public $automarkcompleted;
 
+    /** @var int Define if extra user details should be shown in reports */
+    public $showextrauserdetails;
+
     /** @var int Define if session details should be shown in reports */
     public $showsessiondetails;
 
@@ -125,6 +128,9 @@ class mod_attendance_structure {
 
         $this->pageparams = $pageparams;
 
+        if (isset($pageparams->showextrauserdetails) && $pageparams->showextrauserdetails != $this->showextrauserdetails) {
+            $DB->set_field('attendance', 'showextrauserdetails', $pageparams->showextrauserdetails, array('id' => $this->id));
+        }
         if (isset($pageparams->showsessiondetails) && $pageparams->showsessiondetails != $this->showsessiondetails) {
             $DB->set_field('attendance', 'showsessiondetails', $pageparams->showsessiondetails, array('id' => $this->id));
         }

--- a/db/install.xml
+++ b/db/install.xml
@@ -16,6 +16,7 @@
         <FIELD NAME="subnet" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="Default subnet used when creating sessions."/>
         <FIELD NAME="sessiondetailspos" TYPE="char" LENGTH="5" NOTNULL="true" DEFAULT="left" SEQUENCE="false" COMMENT="Position for the session detail columns related to summary columns."/>
         <FIELD NAME="showsessiondetails" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Define if session details should be shown in reports."/>
+        <FIELD NAME="showextrauserdetails" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Define if extra user details should be shown in reports."/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="Primary key for attendance"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -478,5 +478,15 @@ function xmldb_attendance_upgrade($oldversion=0) {
         upgrade_mod_savepoint(true, 2017120801, 'attendance');
     }
 
+    if ($oldversion < 2018022204) {
+        $table = new xmldb_table('attendance');
+        $field = new xmldb_field('showextrauserdetails', XMLDB_TYPE_INTEGER, '1', XMLDB_UNSIGNED, XMLDB_NOTNULL, null, '1', 'subnet');
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+        upgrade_mod_savepoint(true, 2018022204, 'attendance');
+    }
+
+    
     return $result;
 }

--- a/lang/en/attendance.php
+++ b/lang/en/attendance.php
@@ -418,6 +418,7 @@ $string['setunmarked'] = 'Automatically set when not marked';
 $string['setunmarked_help'] = 'If enabled in the session, set this status if a student has not marked their own attendance.';
 $string['showdefaults'] = 'Show defaults';
 $string['showduration'] = 'Show duration';
+$string['showextrauserdetails'] = 'Show extra user details';
 $string['showsessiondetails'] = 'Show session details';
 $string['somedisabledstatus'] = '(Some options have been removed as the session has started.)';
 $string['sortedgrid'] = 'Sorted grid';

--- a/renderer.php
+++ b/renderer.php
@@ -1236,13 +1236,31 @@ class mod_attendance_renderer extends plugin_renderer_base {
      * @return array Array of html_table_row objects
      */
     protected function get_user_rows(attendance_report_data $reportdata) {
+        global $OUTPUT;
         $rows = array();
         $extrafields = get_extra_user_fields($reportdata->att->context);
+        $showextrauserdetails = $reportdata->pageparams->showextrauserdetails;
+        $params = $reportdata->pageparams->get_significant_params();
+        $text = get_string('users');
+        if ($extrafields) {
+            if ($showextrauserdetails) {
+                $params['showextrauserdetails'] = 0;
+                $url = $reportdata->att->url_report($params);
+                $text .= $OUTPUT->action_icon($url, new pix_icon('t/switch_minus',
+                            get_string('hideextrauserdetails', 'attendance')), null, null);
+            } else {
+                $params['showextrauserdetails'] = 1;
+                $url = $reportdata->att->url_report($params);
+                $text .= $OUTPUT->action_icon($url, new pix_icon('t/switch_plus',
+                            get_string('showextrauserdetails', 'attendance')), null, null);
+                $extrafields = array();
+            }
+        }
         $usercolspan = 1 + count($extrafields);
 
         $row = new html_table_row();
         $row->cells[] = $this->build_header_cell('');
-        $row->cells[] = $this->build_header_cell(get_string('users'), false, false, $usercolspan);
+        $row->cells[] = $this->build_header_cell($text, false, false, $usercolspan);
         $rows[] = $row;
 
         $row = new html_table_row();

--- a/report.php
+++ b/report.php
@@ -46,6 +46,7 @@ $context = context_module::instance($cm->id);
 require_capability('mod/attendance:viewreports', $context);
 
 $pageparams->init($cm);
+$pageparams->showextrauserdetails = optional_param('showextrauserdetails', $attrecord->showextrauserdetails, PARAM_INT);
 $pageparams->showsessiondetails = optional_param('showsessiondetails', $attrecord->showsessiondetails, PARAM_INT);
 $pageparams->sessiondetailspos = optional_param('sessiondetailspos', $attrecord->sessiondetailspos, PARAM_TEXT);
 

--- a/version.php
+++ b/version.php
@@ -23,9 +23,9 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2018022100;
+$plugin->version  = 2018022204;
 $plugin->requires = 2017102700; // Requires 3.4.
-$plugin->release = '3.4.3';
+$plugin->release = '3.4.4';
 $plugin->maturity  = MATURITY_ALPHA;
 $plugin->cron     = 0;
 $plugin->component = 'mod_attendance';


### PR DESCRIPTION
Our users say that the email & dept fields in report are unnecessary & make it unwieldy, and requested making them optional.

This patch makes 'extrafields' hideable as per session details.