### PR TITLE
Fix userpic max-width in attreport.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -186,6 +186,11 @@
 .path-mod-attendance .attreport .narrow {
     width: 1px;
 }
+
+.path-mod-attendance .attreport img.userpicture {
+    max-width: inherit;
+}
+
 .path-mod-attendance .student-password {
     font-size: x-large;
     text-align: center;


### PR DESCRIPTION
Some themes (e.g. adaptable) reasonably set max-width for img to 100%, which messes things up here, and results in image width being ~5px.

It's not really reasonable to expect a theme to know about every plugin out there, nor to expect every plugin to know about every theme, but...

It seems to me that setting the width of a container to less than the desired width of the content (which happens here) is weirder than setting max-width of an element to 100%, so it is more reasonable to fix this here than in the theme.