### PR TITLE
Add description to event, and group to event name if present.

### DIFF
--- a/classes/calendar_helpers.php
+++ b/classes/calendar_helpers.php
@@ -52,9 +52,14 @@ function attendance_create_calendar_event(&$session) {
     $caleventdata->instance       = $session->attendanceid;
     $caleventdata->timestart      = $session->sessdate;
     $caleventdata->timeduration   = $session->duration;
+    $caleventdata->description    = $session->description;
     $caleventdata->eventtype      = 'attendance';
     $caleventdata->timemodified   = time();
     $caleventdata->modulename     = 'attendance';
+
+    if (!empty($session->groupid)) {
+        $caleventdata->name .= " (". get_string('group', 'group') ." ". groups_get_group_name($session->groupid) .")";
+    }
 
     $calevent = new stdClass();
     if ($calevent = calendar_event::create($caleventdata, false)) {


### PR DESCRIPTION
It seems to us that there is no good reason not to use session description as calendar event description.

It is also extremely useful to have group name in calendar event name, as there are several possible use cases where only the event title will be displayed (e.g. when calendar exported to various external calendar progs), and without group name in event name all the different groups' events appear to be duplicates.