### PR TITLE
Fix unit test failure.

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -144,7 +144,7 @@ final class provider implements
             'contextid'    => $context->id,
         ];
 
-        $userlist->add_from_sql('userid', $sql, $params);
+        $userlist->add_from_sql('studentid', $sql, $params);
 
         $sql = "SELECT al.takenby
                  FROM {course_modules} cm
@@ -155,7 +155,7 @@ final class provider implements
                  JOIN {attendance_log} al ON asess.id = al.sessionid
                  WHERE ctx.id = :contextid";
 
-        $userlist->add_from_sql('userid', $sql, $params);
+        $userlist->add_from_sql('takenby', $sql, $params);
 
     }
     /**


### PR DESCRIPTION
The privacy provider is failing some unit tests that have been added to Moodle 3.6 fairly recently (in tool_dataprivacy_expired_contexts_testcase):

* test_process_course_context_with_override_unexpired_role
* test_process_course_context_with_override_expired_role
* test_process_course_context_with_user_in_both_lists

This patch fixes the get_users_in_context() implementation that is the root cause.

To reproduce / test patch:

* vendor/bin/phpunit "tool_dataprivacy_expired_contexts_testcase" admin/tool/dataprivacy/tests/expired_contexts_test.php