### PR TITLE
These lines add the display description on course page option.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -40,6 +40,8 @@ function attendance_supports($feature) {
             return true;
         case FEATURE_GROUPINGS:
             return true;
+		case FEATURE_SHOW_DESCRIPTION:
+            return true;
         case FEATURE_MOD_INTRO:
             return true;
         case FEATURE_BACKUP_MOODLE2:


### PR DESCRIPTION
Hello Dan,

I added these two lines and tested it on my Moodle 3.6.2+ (20190215) installation. 

Best. 

