### PR TITLE
Fixes #378 - Enable QR Code without filling Student Password field

### DIFF
--- a/attendance.php
+++ b/attendance.php
@@ -60,11 +60,6 @@ if (empty($attforsession->includeqrcode)) {
     $qrpass = ''; // Override qrpass if set, as it is not allowed.
 }
 
-if (empty($qrpass)) {
-    // Sesskey is required on this page when QR code not in use.
-    require_sesskey();
-}
-
 // Check to see if autoassignstatus is in use and no password required.
 if ($attforsession->autoassignstatus && empty($attforsession->studentpassword)) {
     $statusid = attendance_session_get_highest_status($att, $attforsession);

--- a/locallib.php
+++ b/locallib.php
@@ -1045,3 +1045,34 @@ function construct_session_full_date_time($datetime, $duration) {
 
     return $sessinfo;
 }
+
+/**
+ * Render the session password.
+ *
+ * @param stdClass $session
+ */
+function attendance_renderpassword($session) {
+    echo html_writer::tag('h2', get_string('passwordgrp', 'attendance'));
+    echo html_writer::span($session->studentpassword, 'student-password');
+}
+
+/**
+ * Render the session QR code.
+ *
+ * @param stdClass $session
+ */
+function attendance_renderqrcode($session) {
+    global $CFG;
+
+    if (strlen($session->studentpassword) > 0) {
+        $qrcodeurl = $CFG->wwwroot . '/mod/attendance/attendance.php?qrpass=' . $session->studentpassword . '&sessid=' . $session->id;
+    } else {
+        $qrcodeurl = $CFG->wwwroot . '/mod/attendance/attendance.php?sessid=' . $session->id;
+    }
+
+    echo html_writer::tag('h3', get_string('qrcode', 'attendance'));
+
+    $barcode = new TCPDF2DBarcode($qrcodeurl, 'QRCODE');
+    $image = $barcode->getBarcodePngData(15, 15);
+    echo html_writer::img('data:image/png;base64,' . base64_encode($image), get_string('qrcode', 'attendance'));
+}

--- a/password.php
+++ b/password.php
@@ -49,15 +49,16 @@ $PAGE->set_context(context_system::instance());
 $PAGE->set_title(get_string('password', 'attendance'));
 
 echo $OUTPUT->header();
-echo html_writer::tag('h2', get_string('passwordgrp', 'attendance'));
-echo html_writer::span($session->studentpassword, 'student-password');
 
-if (isset($session->includeqrcode) && $session->includeqrcode == 1) {
-    $qrcodeurl = $CFG->wwwroot . '/mod/attendance/attendance.php?qrpass=' . $session->studentpassword . '&sessid=' . $session->id;
-    echo html_writer::tag('h3', get_string('qrcode', 'attendance'));
+$showpassword = (isset($session->studentpassword) && strlen($session->studentpassword) > 0);
+$showqr = (isset($session->includeqrcode) && $session->includeqrcode == 1);
 
-    $barcode = new TCPDF2DBarcode($qrcodeurl, 'QRCODE');
-    $image = $barcode->getBarcodePngData(15, 15);
-    echo html_writer::img('data:image/png;base64,' . base64_encode($image), get_string('qrcode', 'attendance'));
+if ($showpassword) {
+    attendance_renderpassword($session);
 }
+
+if ($showqr) {
+    attendance_renderqrcode($session);
+}
+
 echo $OUTPUT->footer();

--- a/renderer.php
+++ b/renderer.php
@@ -312,7 +312,7 @@ class mod_attendance_renderer extends plugin_renderer_base {
      */
     private function construct_date_time_actions(attendance_manage_data $sessdata, $sess) {
         $actions = '';
-        if (!empty($sess->studentpassword) &&
+        if ((!empty($sess->studentpassword) || ($sess->includeqrcode == 1)) &&
             (has_capability('mod/attendance:manageattendances', $sessdata->att->context) ||
             has_capability('mod/attendance:takeattendances', $sessdata->att->context) ||
             has_capability('mod/attendance:changeattendances', $sessdata->att->context))) {


### PR DESCRIPTION
This PR Fixes #378. The user is now able to have a session with no password but still provide the QR code to have students sign in.

**Changes:**
**attendance.php**
- There was a requirement for there to be a 'sesskey' present to view attendace.php page, this has been removed. Viewing the page itself does not change state, so it is unnecessary for there to be a 'sesskey'. The token is important only for the POST request (form submission) which does change state, to prevent CSRF. It was also a blocker to the solution as the user needed a 'sesskey' to get directly to the page. The 'sesskey' is still generated in the form on page load and sent in the form submission to prevent CSRF. There are no security implications to not requiring the 'sesskey' to view the page as the user needs to be authenticated, enrolled in the course and be visiting the page during the sessions attendance time.

**render.php**
- The page now shows the password icon if the session has no password and just the QR code. When #376 is merged, this will be a QR code icon.

**password.php**
- Code refactor

The page now accounts for all 3 session situations:
- Password and QR Code
- Password only
- QR Code only