### PR TITLE
Fixes #379 - Error logic for QR Code import error

### DIFF
--- a/classes/import/sessions.php
+++ b/classes/import/sessions.php
@@ -344,6 +344,12 @@ class sessions {
                 $session->includeqrcode = $pluginconfig->includeqrcode_default;
             } else {
                 $session->includeqrcode = $this->get_column_data($row, $mapping['includeqrcode']);
+
+                if ($session->includeqrcode == 1 && $session->studentscanmark != 1) {
+                    \mod_attendance_notifyqueue::notify_problem(get_string('error:qrcode', 'attendance'));
+                    continue;
+                }
+
             }
 
             $session->statusset = 0;

--- a/lang/en/attendance.php
+++ b/lang/en/attendance.php
@@ -200,6 +200,7 @@ $string['error:sessioncourseinvalid'] = 'A session course is invalid! Skipping.'
 $string['error:sessiondateinvalid'] = 'A session date is invalid! Skipping.';
 $string['error:sessionendinvalid'] = 'A session end time is invalid! Skipping.';
 $string['error:sessionstartinvalid'] = 'A session start time is invalid! Skipping.';
+$string['error:qrcode'] = 'Allow students to record own attendance must be enabled to use QR code! Skipping.';
 $string['errorgroupsnotselected'] = 'Select one or more groups';
 $string['errorinaddingsession'] = 'Error in adding session';
 $string['erroringeneratingsessions'] = 'Error in generating sessions ';


### PR DESCRIPTION
This PR fixes #379. The import functionality will now flag an error is a session has QR enabled but does not have 'Allow students to record own attendance' enabled.

**Changes:**
**sessions.php**
The logic to flag an error if a session has QR enabled but does not have 'Allow students to record own attendance' enabled.
**attendance.php**
Added error string.