### PR TITLE
DBSchema issue

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -127,7 +127,7 @@
         <FIELD NAME="idnumber" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="attendance id or other id relating to this warning."/>
         <FIELD NAME="warningpercent" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Percentage that triggers this warning."/>
         <FIELD NAME="warnafter" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Start warning after this number of taken sessions."/>
-        <FIELD NAME="maxwarn" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Maximum number of warnings to send."/>
+        <FIELD NAME="maxwarn" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Maximum number of warnings to send."/>
         <FIELD NAME="emailuser" TYPE="int" LENGTH="4" NOTNULL="true" SEQUENCE="false" COMMENT="Should the user be notified at this level."/>
         <FIELD NAME="emailsubject" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" COMMENT="Email subject line for emails going to user"/>
         <FIELD NAME="emailcontent" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="The html-formatted text that should be sent to the user"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -566,13 +566,20 @@ function xmldb_attendance_upgrade($oldversion=0) {
     }
 
     if ($oldversion < 2019062000) {
-
         // Make sure sessiondetailspos is not null.
         $table = new xmldb_table('attendance');
         $field = new xmldb_field('sessiondetailspos', XMLDB_TYPE_CHAR, '5', null, XMLDB_NOTNULL, null, 'left', 'subnet');
 
         if ($dbman->field_exists($table, $field)) {
             $dbman->change_field_notnull($table, $field);
+        }
+
+        // Make sure maxwarn has default value of '1'.
+        $table = new xmldb_table('attendance_warning');
+        $field = new xmldb_field('maxwarn', XMLDB_TYPE_INTEGER, '10', null, true, null, '1', 'warnafter');
+
+        if ($dbman->field_exists($table, $field)) {
+            $dbman->change_field_default($table, $field);
         }
 
         // Attendance savepoint reached.

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -565,5 +565,19 @@ function xmldb_attendance_upgrade($oldversion=0) {
         upgrade_mod_savepoint(true, 2019061800, 'attendance');
     }
 
+    if ($oldversion < 2019062000) {
+
+        // Make sure sessiondetailspos is not null.
+        $table = new xmldb_table('attendance');
+        $field = new xmldb_field('sessiondetailspos', XMLDB_TYPE_CHAR, '5', null, XMLDB_NOTNULL, null, 'left', 'subnet');
+
+        if ($dbman->field_exists($table, $field)) {
+            $dbman->change_field_notnull($table, $field);
+        }
+
+        // Attendance savepoint reached.
+        upgrade_mod_savepoint(true, 2019062000, 'attendance');
+    }
+
     return $result;
 }

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2019061800;
+$plugin->version  = 2019062000;
 $plugin->requires = 2018102700; // Requires 3.6.
 $plugin->release = '3.6.7';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
Hi Dan,

There are some mismatches between install.xml and upgrade.php

Regards table "attendance", colum "sessiondetailspos"
**Not null in install.xml:**
https://github.com/danmarsden/moodle-mod_attendance/blob/master/db/install.xml#L17
**Null value instead of XMLDB_NOTNULL:**
https://github.com/danmarsden/moodle-mod_attendance/blob/master/db/upgrade.php#L206 

Regards table "attendance_warning", colum "maxwarn":
The default value is missing in install.xm
https://github.com/danmarsden/moodle-mod_attendance/blob/master/db/install.xml#L130
It is '1' in upgrade.php:
https://github.com/danmarsden/moodle-mod_attendance/blob/master/db/upgrade.php#L414


