### PR TITLE
Prevent ORA-00918: column ambiguously defined

### DIFF
--- a/classes/structure.php
+++ b/classes/structure.php
@@ -786,7 +786,7 @@ class mod_attendance_structure {
         $fields = array_merge($fields, $extrafields);
 
         $userfields = user_picture::fields('u', $fields);
-        $userfields_extended = implode(',', array_unique(explode(',', str_replace(' ', '', $userfields.',u.id, u.firstname, u.lastname, u.email'))));
+        $userfieldsextended = implode(',', array_unique(explode(',', str_replace(' ', '', $userfields.',u.id, u.firstname, u.lastname, u.email'))));
 
         if (empty($this->pageparams->sort)) {
             $this->pageparams->sort = ATT_SORT_DEFAULT;
@@ -809,7 +809,7 @@ class mod_attendance_structure {
                     $groups = $groupid;
                 }
                 $users = get_users_by_capability($this->context, 'mod/attendance:canbelisted',
-                    $userfields_extended,
+                    $userfieldsextended,
                     $orderby, $startusers, $usersperpage, $groups,
                     '', false, true);
             } else {
@@ -825,7 +825,7 @@ class mod_attendance_structure {
                     $groups = $groupid;
                 }
                 $users = get_users_by_capability($this->context, 'mod/attendance:canbelisted',
-                    $userfields_extended,
+                    $userfieldsextended,
                     $orderby, '', '', $groups,
                     '', false, true);
             } else {

--- a/classes/structure.php
+++ b/classes/structure.php
@@ -786,6 +786,7 @@ class mod_attendance_structure {
         $fields = array_merge($fields, $extrafields);
 
         $userfields = user_picture::fields('u', $fields);
+        $userfields_extended = implode(',', array_unique(explode(',', str_replace(' ', '', $userfields.',u.id, u.firstname, u.lastname, u.email'))));
 
         if (empty($this->pageparams->sort)) {
             $this->pageparams->sort = ATT_SORT_DEFAULT;
@@ -808,7 +809,7 @@ class mod_attendance_structure {
                     $groups = $groupid;
                 }
                 $users = get_users_by_capability($this->context, 'mod/attendance:canbelisted',
-                    $userfields.',u.id, u.firstname, u.lastname, u.email',
+                    $userfields_extended,
                     $orderby, $startusers, $usersperpage, $groups,
                     '', false, true);
             } else {
@@ -824,7 +825,7 @@ class mod_attendance_structure {
                     $groups = $groupid;
                 }
                 $users = get_users_by_capability($this->context, 'mod/attendance:canbelisted',
-                    $userfields.',u.id, u.firstname, u.lastname, u.email',
+                    $userfields_extended,
                     $orderby, '', '', $groups,
                     '', false, true);
             } else {


### PR DESCRIPTION
With grouping enabled and on Oracle the resulting query fails with an error:

```
https://my.moodle.ca/mod/attendance/take.php?id=1262694&sessionid=566&grouptype=0
Debug info: ORA-00918: column ambiguously defined
SELECT *
FROM (SELECT u.id,u.picture,u.firstname,u.lastname,u.firstnamephonetic,u.lastnamephonetic,u.middlename,u.alternatename,u.imagealt,u.email,u.username,u.idnumber,u.institution,u.department,u.id, u.firstname, u.lastname, u.email
FROM m_user u
LEFT OUTER JOIN (SELECT DISTINCT userid
FROM m_groups_members
WHERE groupid = :o_grp7
) gm ON gm.userid = u.id
JOIN (SELECT DISTINCT userid
FROM m_role_assignments
WHERE contextid IN (1,430672,929566,2048955,2064976)
AND roleid IN (5,1261,1081,1281,1301,1321)
) ra ON ra.userid = u.id
WHERE u.deleted = 0 AND u.id <> :o_guestid AND (gm.userid IS NOT NULL)
ORDER BY u.lastname, u.firstname, u.id)
WHERE rownum <= :o_oracle_num_rows
[array (
'o_grp7' => 111522,
'o_guestid' => '1',
'o_oracle_num_rows' => 25,
)]
Error code: dmlreadexception

Stack trace:
line 486 of /lib/dml/moodle_database.php: dml_read_exception thrown
line 277 of /lib/dml/oci_native_moodle_database.php: call to moodle_database->query_end()
line 1179 of /lib/dml/oci_native_moodle_database.php: call to oci_native_moodle_database->query_end()
line 3634 of /lib/accesslib.php: call to oci_native_moodle_database->get_records_sql()
line 787 of /mod/attendance/classes/structure.php: call to get_users_by_capability()
line 370 of /mod/attendance/renderables.php: call to mod_attendance_structure->get_users()
line 99 of /mod/attendance/take.php: call to attendance_take_data->__construct()
```

The problem is that it's possible to have duplicated columns - in this case: u.id, u.firstname, u.lastname, u.email.

This change removes duplicate u.* columns.