### PR TITLE
Upgrade.php fix to sync with install.xml

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -628,5 +628,32 @@ function xmldb_attendance_upgrade($oldversion=0) {
 
     }
 
+    if ($oldversion < 2019080802) {
+
+        // Changing nullability of field sessiondetailspos on table attendance to not null.
+        $table = new xmldb_table('attendance');
+        $field = new xmldb_field('sessiondetailspos', XMLDB_TYPE_CHAR, '5', null, XMLDB_NOTNULL, null, 'left', 'subnet');
+
+        // Launch change of nullability for field sessiondetailspos.
+        $dbman->change_field_notnull($table, $field);
+
+        // Changing the default of field preventsharedip on table attendance_sessions to 1.
+        $table = new xmldb_table('attendance_sessions');
+        $field = new xmldb_field('preventsharedip', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1', 'absenteereport');
+
+        // Launch change of default for field preventsharedip.
+        $dbman->change_field_default($table, $field);
+
+        // Changing the default of field maxwarn on table attendance_warning to drop it.
+        $table = new xmldb_table('attendance_warning');
+        $field = new xmldb_field('maxwarn', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null, 'warnafter');
+
+        // Launch change of default for field maxwarn.
+        $dbman->change_field_default($table, $field);
+
+        // Attendance savepoint reached.
+        upgrade_mod_savepoint(true, 2019080802, 'attendance');
+    }
+
     return $result;
 }

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2019080801;
+$plugin->version  = 2019080802;
 $plugin->requires = 2019072500; // Requires 3.8.
 $plugin->release = '3.8.0';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
FIxes fields where Upgrade.php sets values differently to install.xml, resolves problems from existing installs when running admin/cli/check_database_schema