### PR TITLE
Added return type because of random PHPUnit failure.

### DIFF
--- a/classes/structure.php
+++ b/classes/structure.php
@@ -193,7 +193,7 @@ class mod_attendance_structure {
      *
      * @return array of records or an empty array
      */
-    public function get_today_sessions() {
+    public function get_today_sessions() : array {
         global $DB;
 
         $start = usergetmidnight(time());


### PR DESCRIPTION
Hello,

We have been getting some random PHPUnit failures on `test_get_courses_with_today_sessions_multiple_instances`:
```
mod_attendance_external_testcase::test_get_courses_with_today_sessions_multiple_instances
invalid_response_exception: Invalid response value detected (attendance_instances => Invalid response value detected (Error in response - Missing following required key in a single structure: today_sessions): Error in response - Missing following required key in a single structure: today_sessions)

lib/externallib.php:442
lib/externallib.php:457
mod/attendance/tests/externallib_test.php:129
lib/phpunit/classes/advanced_testcase.php:91
```
I think adding a return type to the method which creates the "today sessions" might help pinpoint the culprit. 