### PR TITLE
Add phpunit group to externallib test

### DIFF
--- a/tests/externallib_test.php
+++ b/tests/externallib_test.php
@@ -39,6 +39,7 @@ require_once($CFG->dirroot . '/mod/attendance/externallib.php');
  * @category   test
  * @copyright  2015 Caio Bressan Doneda
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @group      mod_attendance
  */
 class mod_attendance_external_testcase extends externallib_advanced_testcase {
     /** @var coursecat */


### PR DESCRIPTION
This allows you to run the mod attendance tests without running everything else in Moodle.
E.g.
`vendor/bin/phpunit --group mod_attendance`