### PR TITLE
Only allow successful QR checkin if logged-in user was in session

### DIFF
--- a/lang/en/attendance.php
+++ b/lang/en/attendance.php
@@ -57,6 +57,7 @@ $string['attendance:viewreports'] = 'Viewing Reports';
 $string['attendance:viewsummaryreports'] = 'View course summary reports';
 $string['attendance:warningemails'] = 'Can be subscribed to emails with absentee users';
 $string['attendance_already_submitted'] = 'Your attendance has already been set.';
+$string['attendance_bad_group'] = 'You tried to set attendance at an event that is for a group you are not a member of.';
 $string['attendance_no_status'] = 'No valid status was available - you may be too late to record attendance.';
 $string['attendancedata'] = 'Attendance data';
 $string['attendancefile'] = 'Attendance file (csv format)';

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2021072300;
+$plugin->version  = 2021072301;
 $plugin->requires = 2021050400; // Requires 3.11.
 $plugin->release = '3.11.5';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
If a student wasn't supposed to be in a session, they've probably scanned
the wrong QR code and it's not helpful to give them a "success" message.