### PR TITLE
Correct timestamps in database for DST days

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -847,7 +847,13 @@ function attendance_construct_sessions_data_for_add($formdata, mod_attendance_st
         }
     } else {
         $sess = new stdClass();
-        $sess->sessdate = $sessiondate;
+        $sess->sessdate = make_timestamp(
+            date("Y", $formdata->sessiondate),
+            date("m", $formdata->sessiondate),
+            date("d", $formdata->sessiondate),
+            $formdata->sestime['starthour'],
+            $formdata->sestime['startminute']
+        );
         $sess->duration = $duration;
         $sess->descriptionitemid = $formdata->sdescription['itemid'];
         $sess->description = $formdata->sdescription['text'];


### PR DESCRIPTION
Use `make_timestamp()` in `attendance_construct_sessions_data_for_add()` function to calculate correct timestamp - taking into account timezones and DST (Daylight Saving Time) for both cases:

- multiple sessions
- and single session.