### PR TITLE
Fixed get_courses_with_today_sessions method when there are attendance instances in different days

### DIFF
--- a/classes/attendance_webservices_handler.php
+++ b/classes/attendance_webservices_handler.php
@@ -65,11 +65,12 @@ class attendance_handler {
                 $cm->id = $attendance->coursemodule;
 
                 $att = new mod_attendance_structure($att, $cm, $course, $context);
-                $course->attendance_instance[$att->id] = array();
-                $course->attendance_instance[$att->id]['name'] = $att->name;
+                
                 $todaysessions = $att->get_today_sessions();
 
                 if (!empty($todaysessions)) {
+                    $course->attendance_instance[$att->id] = array();
+                    $course->attendance_instance[$att->id]['name'] = $att->name;
                     $course->attendance_instance[$att->id]['today_sessions'] = $todaysessions;
                     $coursessessions[$course->id] = $course;
                 }


### PR DESCRIPTION
By only adding an attendance_instance if there are sessions for today, the response will no longer be invalid when some of the attendance activities are in different days or do not have any sessions. Fixes #488 