### PR TITLE
Removed time dependency from multiple session test

### DIFF
--- a/tests/externallib_test.php
+++ b/tests/externallib_test.php
@@ -129,7 +129,6 @@ class mod_attendance_external_testcase extends externallib_advanced_testcase {
 
         // Just add the same session.
         $secondsession = clone $this->sessions[0];
-        $secondsession->sessdate += 3600;
 
         $second->add_sessions([$secondsession]);
 


### PR DESCRIPTION
This removes the potential for the 2 attendance sessions to land on different days depending on the execution time of the test. The change in time is not actually used in the test, and does not need to be present, as there is 2 seperate activity instances already.

Fixes #512 