### PR TITLE
Backport of 4.0 functionality for activity level imports to 3.11

### DIFF
--- a/classes/import/sessions.php
+++ b/classes/import/sessions.php
@@ -66,6 +66,9 @@ class sessions {
     /** @var \core\progress\display_if_slow|null $progress The progress bar instance. */
     protected $progress = null;
 
+    /** @var bool $courseprovided If course has been provided we don't need to map the course field*/
+    protected $courseprovided = false;
+
     /**
      * Store an error message for display later
      *
@@ -90,30 +93,36 @@ class sessions {
      *
      * @return array The headers (lang strings)
      */
-    public static function list_required_headers() {
-        return array(
-            get_string('courseshortname', 'attendance'),
-            get_string('groups', 'attendance'),
-            get_string('sessiondate', 'attendance'),
-            get_string('from', 'attendance'),
-            get_string('to', 'attendance'),
-            get_string('description', 'attendance'),
-            get_string('repeaton', 'attendance'),
-            get_string('repeatevery', 'attendance'),
-            get_string('repeatuntil', 'attendance'),
-            get_string('studentscanmark', 'attendance'),
-            get_string('passwordgrp', 'attendance'),
-            get_string('randompassword', 'attendance'),
-            get_string('subnet', 'attendance'),
-            get_string('automark', 'attendance'),
-            get_string('autoassignstatus', 'attendance'),
-            get_string('absenteereport', 'attendance'),
-            get_string('preventsharedip', 'attendance'),
-            get_string('preventsharediptime', 'attendance'),
-            get_string('calendarevent', 'attendance'),
-            get_string('includeqrcode', 'attendance'),
-            get_string('rotateqrcode', 'attendance'),
-        );
+    public function list_required_headers() {
+        $headers = [];
+
+        // If we don't have the "courseprovided" then include the courseshortname header.
+        if (!$this->courseprovided) {
+            $headers[] = get_string('courseshortname', 'attendance');
+        }
+
+        $headers[] = get_string('groups', 'attendance');
+        $headers[] = get_string('sessiondate', 'attendance');
+        $headers[] = get_string('from', 'attendance');
+        $headers[] = get_string('to', 'attendance');
+        $headers[] = get_string('description', 'attendance');
+        $headers[] = get_string('repeaton', 'attendance');
+        $headers[] = get_string('repeatevery', 'attendance');
+        $headers[] = get_string('repeatuntil', 'attendance');
+        $headers[] = get_string('studentscanmark', 'attendance');
+        $headers[] = get_string('passwordgrp', 'attendance');
+        $headers[] = get_string('randompassword', 'attendance');
+        $headers[] = get_string('subnet', 'attendance');
+        $headers[] = get_string('automark', 'attendance');
+        $headers[] = get_string('autoassignstatus', 'attendance');
+        $headers[] = get_string('absenteereport', 'attendance');
+        $headers[] = get_string('preventsharedip', 'attendance');
+        $headers[] = get_string('preventsharediptime', 'attendance');
+        $headers[] = get_string('calendarevent', 'attendance');
+        $headers[] = get_string('includeqrcode', 'attendance');
+        $headers[] = get_string('rotateqrcode', 'attendance');
+
+        return $headers;
     }
 
     /**
@@ -128,58 +137,48 @@ class sessions {
     /**
      * Read the data from the mapping form.
      *
-     * @param array $data The mapping data.
+     * @param object $data The mapping data.
      */
     protected function read_mapping_data($data) {
-        if ($data) {
-            return array(
-                'course' => $data->header0,
-                'groups' => $data->header1,
-                'sessiondate' => $data->header2,
-                'from' => $data->header3,
-                'to' => $data->header4,
-                'description' => $data->header5,
-                'repeaton' => $data->header6,
-                'repeatevery' => $data->header7,
-                'repeatuntil' => $data->header8,
-                'studentscanmark' => $data->header9,
-                'passwordgrp' => $data->header10,
-                'randompassword' => $data->header11,
-                'subnet' => $data->header12,
-                'automark' => $data->header13,
-                'autoassignstatus' => $data->header14,
-                'absenteereport' => $data->header15,
-                'preventsharedip' => $data->header16,
-                'preventsharediptime' => $data->header17,
-                'calendarevent' => $data->header18,
-                'includeqrcode' => $data->header19,
-                'rotateqrcode' => $data->header20,
-            );
-        } else {
-            return array(
-                'course' => 0,
-                'groups' => 1,
-                'sessiondate' => 2,
-                'from' => 3,
-                'to' => 4,
-                'description' => 5,
-                'repeaton' => 6,
-                'repeatevery' => 7,
-                'repeatuntil' => 8,
-                'studentscanmark' => 9,
-                'passwordgrp' => 10,
-                'randompassword' => 11,
-                'subnet' => 12,
-                'automark' => 13,
-                'autoassignstatus' => 14,
-                'absenteereport' => 15,
-                'preventsharedip' => 16,
-                'preventsharediptime' => 17,
-                'calendarevent' => 18,
-                'includeqrcode' => 19,
-                'rotateqrcode' => 20
-            );
+
+        $headerkeys = [];
+        // If we have don't have "courseprovided" then the mapping data is increased by one to include the course field.
+        if (!$this->courseprovided) {
+            $headerkeys[] = 'course';
         }
+
+        $headerkeys[] = 'groups';
+        $headerkeys[] = 'sessiondate';
+        $headerkeys[] = 'from';
+        $headerkeys[] = 'to';
+        $headerkeys[] = 'description';
+        $headerkeys[] = 'repeaton';
+        $headerkeys[] = 'repeatevery';
+        $headerkeys[] = 'repeatuntil';
+        $headerkeys[] = 'studentscanmark';
+        $headerkeys[] = 'passwordgrp';
+        $headerkeys[] = 'randompassword';
+        $headerkeys[] = 'subnet';
+        $headerkeys[] = 'automark';
+        $headerkeys[] = 'autoassignstatus';
+        $headerkeys[] = 'absenteereport';
+        $headerkeys[] = 'preventsharedip';
+        $headerkeys[] = 'preventsharediptime';
+        $headerkeys[] = 'calendarevent';
+        $headerkeys[] = 'includeqrcode';
+        $headerkeys[] = 'rotateqrcode';
+
+        // Subtract 1 for 0 indexed arrays.
+        $valuecount = count($headerkeys) - 1;
+        if ($data) {
+            $headervalues = [];
+            for ($i = 0; $i <= $valuecount; $i++) {
+                $headervalues[] = $data->{"header$i"} ?? null;
+            }
+        } else {
+            $headervalues = range(0, $valuecount);
+        }
+        return array_combine($headerkeys, $headervalues);
     }
 
     /**
@@ -205,12 +204,18 @@ class sessions {
      * @param string $importid The id of the csv import.
      * @param array $mappingdata The mapping data from the import form.
      * @param bool $useprogressbar Whether progress bar should be displayed, to avoid html output on CLI.
+     * @param bool $courseshortname Course shortname for the course level imports.
+     * @param bool $attendanceid ID for the attendance activity for course level imports.
      */
     public function __construct($text = null, $encoding = null, $delimiter = null, $importid = 0,
-                                $mappingdata = null, $useprogressbar = false) {
-        global $CFG;
+                                $mappingdata = null, $useprogressbar = false, $courseshortname = null, $attendanceid = null) {
+        global $CFG, $DB;
 
         require_once($CFG->libdir . '/csvlib.class.php');
+
+        if ($courseshortname) {
+            $this->courseprovided = true;
+        }
 
         $pluginconfig = get_config('attendance');
 
@@ -252,7 +257,12 @@ class sessions {
             $mapping = $this->read_mapping_data($mappingdata);
 
             $session = new stdClass();
-            $session->course = $this->get_column_data($row, $mapping['course']);
+            $session->attendanceid = $attendanceid;
+            if ($this->courseprovided) {
+                $session->course = $courseshortname;
+            } else {
+                $session->course = $this->get_column_data($row, $mapping['course']);
+            }
             if (empty($session->course)) {
                 \mod_attendance_notifyqueue::notify_problem(get_string('error:sessioncourseinvalid', 'attendance'));
                 continue;
@@ -298,7 +308,7 @@ class sessions {
             $session->sdescription['text'] = '<p>' . $this->get_column_data($row, $mapping['description']) . '</p>';
             $session->sdescription['format'] = FORMAT_HTML;
             $session->sdescription['itemid'] = 0;
-            $session->passwordgrp = $this->get_column_data($row, $mapping['passwordgrp']);
+            $session->studentpassword = $this->get_column_data($row, $mapping['passwordgrp']);
             $session->subnet = $this->get_column_data($row, $mapping['subnet']);
             // Set session subnet restriction. Use the default activity level subnet if there isn't one set for this session.
             if (empty($session->subnet)) {
@@ -307,52 +317,67 @@ class sessions {
                 $session->usedefaultsubnet = '';
             }
 
-            if ($mapping['studentscanmark'] == -1) {
+            $studentscanmark = $this->get_column_data($row, $mapping['studentscanmark']);
+            if ($studentscanmark == -1) {
                 $session->studentscanmark = $pluginconfig->studentscanmark_default;
             } else {
-                $session->studentscanmark = $this->get_column_data($row, $mapping['studentscanmark']);
+                $session->studentscanmark = $studentscanmark;
             }
-            if ($mapping['randompassword'] == -1) {
+
+            $randompassword = $this->get_column_data($row, $mapping['randompassword']);
+            if ($randompassword == -1) {
                 $session->randompassword = $pluginconfig->randompassword_default;
             } else {
-                $session->randompassword = $this->get_column_data($row, $mapping['randompassword']);
+                $session->randompassword = $randompassword;
             }
-            if ($mapping['automark'] == -1) {
+
+            $automark = $this->get_column_data($row, $mapping['automark']);
+            if ($automark == -1) {
                 $session->automark = $pluginconfig->automark_default;
             } else {
-                $session->automark = $this->get_column_data($row, $mapping['automark']);
+                $session->automark = $automark;
             }
-            if ($mapping['autoassignstatus'] == -1) {
+
+            $autoassignstatus = $this->get_column_data($row, $mapping['autoassignstatus']);
+            if ($autoassignstatus == -1) {
                 $session->autoassignstatus = $pluginconfig->autoassignstatus;
             } else {
-                $session->autoassignstatus = $this->get_column_data($row, $mapping['autoassignstatus']);
+                $session->autoassignstatus = $autoassignstatus;
             }
-            if ($mapping['absenteereport'] == -1) {
+
+            $absenteereport = $this->get_column_data($row, $mapping['absenteereport']);
+            if ($absenteereport == -1) {
                 $session->absenteereport = $pluginconfig->absenteereport_default;
             } else {
-                $session->absenteereport = $this->get_column_data($row, $mapping['absenteereport']);
+                $session->absenteereport = $absenteereport;
             }
-            if ($mapping['preventsharedip'] == -1) {
+
+            $preventsharedip = $this->get_column_data($row, $mapping['preventsharedip']);
+            if ($preventsharedip == -1) {
                 $session->preventsharedip = $pluginconfig->preventsharedip;
             } else {
-                $session->preventsharedip = $this->get_column_data($row, $mapping['preventsharedip']);
+                $session->preventsharedip = $preventsharedip;
             }
-            if ($mapping['preventsharediptime'] == -1) {
+
+            $preventsharediptime = $this->get_column_data($row, $mapping['preventsharediptime']);
+            if ($preventsharediptime == -1) {
                 $session->preventsharediptime = $pluginconfig->preventsharediptime;
             } else {
-                $session->preventsharediptime = $this->get_column_data($row, $mapping['preventsharediptime']);
+                $session->preventsharediptime = $preventsharediptime;
             }
 
-            if ($mapping['calendarevent'] == -1) {
+            $calendarevent = $this->get_column_data($row, $mapping['calendarevent']);
+            if ($calendarevent == -1) {
                 $session->calendarevent = $pluginconfig->calendarevent_default;
             } else {
-                $session->calendarevent = $this->get_column_data($row, $mapping['calendarevent']);
+                $session->calendarevent = $calendarevent;
             }
 
-            if ($mapping['includeqrcode'] == -1) {
+            $includeqrcode = $this->get_column_data($row, $mapping['includeqrcode']);
+            if ($includeqrcode == -1) {
                 $session->includeqrcode = $pluginconfig->includeqrcode_default;
             } else {
-                $session->includeqrcode = $this->get_column_data($row, $mapping['includeqrcode']);
+                $session->includeqrcode = $includeqrcode;
 
                 if ($session->includeqrcode == 1 && $session->studentscanmark != 1) {
                     \mod_attendance_notifyqueue::notify_problem(get_string('error:qrcode', 'attendance'));
@@ -360,10 +385,41 @@ class sessions {
                 }
 
             }
-            if ($mapping['rotateqrcode'] == -1) {
+
+            $rotateqrcode = $this->get_column_data($row, $mapping['rotateqrcode']);
+            if ($rotateqrcode == -1) {
                 $session->rotateqrcode = $pluginconfig->rotateqrcode_default;
             } else {
-                $session->rotateqrcode = $this->get_column_data($row, $mapping['rotateqrcode']);
+                $session->rotateqrcode = $rotateqrcode;
+            }
+            if ($session->rotateqrcode) {
+                $session->includeqrcode = 0;
+            }
+
+            // Reapeating session settings.
+            if (empty($mapping['repeaton'])) {
+                $session->sdays = [];
+            } else {
+                $repeaton = $this->get_column_data($row, $mapping['repeaton']);
+                $sdays = array_map('trim', explode(',', $repeaton));
+                $session->sdays = array_fill_keys($sdays, 1);
+            }
+            if (empty($mapping['repeatevery'])) {
+                $session->period = '';
+            } else {
+                $session->period = $this->get_column_data($row, $mapping['repeatevery']);
+            }
+            if (empty($mapping['repeatuntil'])) {
+                $session->sessionenddate = null;
+            } else {
+                $session->sessionenddate = strtotime($this->get_column_data($row, $mapping['repeatuntil']));
+            }
+            $course = $DB->get_record('course', ['shortname' => $session->course]);
+            if ($course) {
+                $session->coursestartdate = $course;
+            }
+            if (!empty($session->sdays) && !empty($session->period) && !empty($session->sessionenddate) && !empty($session->coursestartdate)) {
+                $session->addmultiply = 1;
             }
 
             $session->statusset = 0;
@@ -440,10 +496,12 @@ class sessions {
                         $session->groups = $groupids;
                     }
 
-                    // Get activities in course.
-                    $activities = $DB->get_recordset('attendance', array(
-                        'course' => $course->id
-                    ), 'id', 'id');
+                    // Get activities in course or specific activity if provided.
+                    $params = ['course' => $course->id];
+                    if ($session->attendanceid) {
+                        $params['id'] = $session->attendanceid;
+                    }
+                    $activities = $DB->get_recordset('attendance', $params);
 
                     foreach ($activities as $activity) {
                         // Build the session data.

--- a/classes/structure.php
+++ b/classes/structure.php
@@ -397,6 +397,16 @@ class mod_attendance_structure {
     }
 
     /**
+     * Get url for import.
+     *
+     * @return moodle_url of import.php for attendance instance
+     */
+    public function url_import() : moodle_url {
+        $params = ['id' => $this->cm->id];
+        return new moodle_url('/mod/attendance/import.php', $params);
+    }
+
+    /**
      * Get url for export.
      *
      * @return moodle_url of export.php for attendance instance

--- a/db/access.php
+++ b/db/access.php
@@ -100,6 +100,16 @@ $capabilities = array(
         )
     ),
 
+    'mod/attendance:import' => array(
+        'riskbitmask' => RISK_PERSONAL,
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_MODULE,
+        'archetypes' => array(
+            'editingteacher' => CAP_ALLOW,
+            'manager' => CAP_ALLOW
+        )
+    ),
+
     'mod/attendance:export' => array(
         'riskbitmask' => RISK_PERSONAL,
         'captype' => 'read',

--- a/import.php
+++ b/import.php
@@ -1,0 +1,110 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Import attendance sessions
+ *
+ * @package   mod_attendance
+ * @author    Simon Thornett <simon.thornett@catalyst-eu.net>
+ * @copyright Catalyst IT, 2022
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+define('NO_OUTPUT_BUFFERING', true);
+
+require_once(dirname(__FILE__) . '/../../config.php');
+require_once(dirname(__FILE__) . '/locallib.php');
+require_once(dirname(__FILE__) . '/renderables.php');
+require_once(dirname(__FILE__) . '/renderhelpers.php');
+require_once($CFG->libdir . '/formslib.php');
+
+$id = required_param('id', PARAM_INT);
+$cm = get_coursemodule_from_id('attendance', $id, 0, false, MUST_EXIST);
+$course = $DB->get_record('course', array('id' => $cm->course), '*', MUST_EXIST);
+$att = $DB->get_record('attendance', array('id' => $cm->instance), '*', MUST_EXIST);
+
+require_login($course, true, $cm);
+
+$context = context_module::instance($cm->id);
+require_capability('mod/attendance:import', $context);
+
+$att = new mod_attendance_structure($att, $cm, $course, $context);
+
+$PAGE->set_url($att->url_import());
+$PAGE->set_title($course->shortname . ": " . $att->name);
+$PAGE->set_heading($course->fullname);
+$PAGE->force_settings_menu(true);
+$PAGE->set_cacheable(true);
+$PAGE->navbar->add(get_string('import', 'attendance'));
+
+$formparams = array('course' => $course, 'cm' => $cm, 'modcontext' => $context);
+
+$form = null;
+if (optional_param('confirm', 0, PARAM_BOOL)) {
+    $importer = new \mod_attendance\import\sessions(null, null, null, 0, null, false, $course->shortname, $att->id);
+    $form = new \mod_attendance\form\import\sessions_confirm($att->url_import(), $importer);
+} else {
+    $form = new \mod_attendance\form\import\sessions($att->url_import(), $formparams);
+}
+
+if ($form->is_cancelled()) {
+    $form = new \mod_attendance\form\import\sessions($att->url_import(), $formparams);
+} else if ($data = $form->get_data()) {
+    require_sesskey();
+    if ($data->confirm) {
+        $importid = $data->importid;
+        $importer = new \mod_attendance\import\sessions(
+            $att->url_import(),
+            null,
+            null,
+            $importid,
+            $data,
+            false,
+            $course->shortname,
+            $att->id
+        );
+
+        $error = $importer->get_error();
+        if ($error) {
+            $form = new \mod_attendance\form\import\sessions($att->url_import(), $formparams);
+            $form->set_import_error($error);
+        } else {
+            $sessions = $importer->import();
+            redirect($att->url_import());
+        }
+    } else {
+        $text = $form->get_file_content('importfile');
+        $encoding = $data->encoding;
+        $delimiter = $data->delimiter_name;
+        $importer = new \mod_attendance\import\sessions($text, $encoding, $delimiter, 0, null, false, $course->shortname, $att->id);
+        $confirmform = new \mod_attendance\form\import\sessions_confirm($att->url_import(), $importer);
+        $form = $confirmform;
+        $pagetitle = get_string('confirmcolumnmappings', 'attendance');
+    }
+}
+
+$output = $PAGE->get_renderer('mod_attendance');
+$tabs = new attendance_tabs($att, attendance_tabs::TAB_IMPORT);
+echo $output->header();
+echo $output->heading(get_string('attendanceforthecourse', 'attendance') . ' :: ' . format_string($course->fullname));
+mod_attendance_notifyqueue::show();
+echo $output->render($tabs);
+
+$form->display();
+
+echo $OUTPUT->footer();
+
+

--- a/lang/en/attendance.php
+++ b/lang/en/attendance.php
@@ -49,6 +49,7 @@ $string['attendance:canbelisted'] = 'Appears in the roster';
 $string['attendance:changeattendances'] = 'Changing Attendances';
 $string['attendance:changepreferences'] = 'Changing Preferences';
 $string['attendance:export'] = 'Export Reports';
+$string['attendance:import'] = 'Import sessions from file (csv)';
 $string['attendance:manageattendances'] = 'Manage Attendances';
 $string['attendance:managetemporaryusers'] = 'Manage temporary users';
 $string['attendance:takeattendances'] = 'Taking Attendances';

--- a/locallib.php
+++ b/locallib.php
@@ -261,7 +261,7 @@ function attendance_form_sessiondate_selector (MoodleQuickForm $mform) {
     for ($i = 0; $i <= 23; $i++) {
         $hours[$i] = sprintf("%02d", $i);
     }
-    for ($i = 0; $i < 60; $i += 5) {
+    for ($i = 0; $i < 60; $i++) {
         $minutes[$i] = sprintf("%02d", $i);
     }
 

--- a/password.php
+++ b/password.php
@@ -64,13 +64,12 @@ if ($showpassword  && !$rotateqr) {
     attendance_renderpassword($session);
 }
 
-if ($showqr) {
-    attendance_renderqrcode($session);
-}
 
 if ($rotateqr) {
     attendance_generate_passwords($session);
     attendance_renderqrcoderotate($session);
+} else if ($showqr) {
+    attendance_renderqrcode($session);
 }
 
 echo $OUTPUT->footer();

--- a/renderables.php
+++ b/renderables.php
@@ -55,6 +55,8 @@ class attendance_tabs implements renderable {
     const TAB_WARNINGS = 8;
     /** Absentee tab */
     const TAB_ABSENTEE      = 9;
+    /** Import tab */
+    const TAB_IMPORT        = 10;
     /** @var int current tab */
     public $currenttab;
 
@@ -104,6 +106,11 @@ class attendance_tabs implements renderable {
             get_config('attendance', 'enablewarnings')) {
             $toprow[] = new tabobject(self::TAB_ABSENTEE, $this->att->url_absentee()->out(),
                 get_string('absenteereport', 'attendance'));
+        }
+
+        if (has_capability('mod/attendance:import', $context)) {
+            $toprow[] = new tabobject(self::TAB_IMPORT, $this->att->url_import()->out(),
+                            get_string('import', 'attendance'));
         }
 
         if (has_capability('mod/attendance:export', $context)) {

--- a/version.php
+++ b/version.php
@@ -23,9 +23,9 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2021082601;
+$plugin->version  = 2021082602;
 $plugin->requires = 2021051700; // Requires 3.11.
-$plugin->release = '3.11.11';
+$plugin->release = '3.11.12';
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->cron     = 0;
 $plugin->component = 'mod_attendance';


### PR DESCRIPTION
@danmarsden This is the backport to 3.11 from 4.0 for the activity level import (this also includes the lang string fix. Apologies for that)

I have tested locally and all appears to work as before

Tagging @wilenius for visibility