### PR TITLE
Add support for custom identity fields; fixes #548

### DIFF
--- a/classes/form/export.php
+++ b/classes/form/export.php
@@ -111,7 +111,7 @@ class export extends \moodleform {
             $checkedfields['ident[id]'] = true;
         }
 
-        $extrafields = \core_user\fields::for_identity($modcontext)->get_required_fields();
+        $extrafields = \core_user\fields::for_identity($modcontext, false)->get_required_fields();
         foreach ($extrafields as $field) {
             $ident[] =& $mform->createElement('checkbox',  $field, '', get_string( $field));
             $mform->setType($field, PARAM_NOTAGS);
@@ -120,7 +120,6 @@ class export extends \moodleform {
 
         require_once($CFG->dirroot . '/user/profile/lib.php');
         $customfields = profile_get_custom_fields();
-
         foreach ($customfields as $field) {
             if ((is_siteadmin($USER) || $field->visible == PROFILE_VISIBLE_ALL || $field->visible == PROFILE_VISIBLE_TEACHERS)
             && in_array($field->shortname, explode(',', $adminsetfields))) {

--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -745,7 +745,7 @@ class renderer extends plugin_renderer_base {
             $extrasearchfields = explode(',', $CFG->showuseridentity);
         }
         foreach ($extrasearchfields as $field) {
-            $table->head[] = get_string($field);
+            $table->head[] = \core_user\fields::get_display_name($field);
             $table->align[] = 'left';
         }
         foreach ($takedata->statuses as $st) {
@@ -2125,7 +2125,7 @@ class renderer extends plugin_renderer_base {
         $rows = array();
 
         $bulkmessagecapability = has_capability('moodle/course:bulkmessaging', $this->page->context);
-        $extrafields = \core_user\fields::for_identity($reportdata->att->context)->get_required_fields();
+        $extrafields = \core_user\fields::for_identity($reportdata->att->context, true)->get_required_fields();
         $showextrauserdetails = $reportdata->pageparams->showextrauserdetails;
         $params = $reportdata->pageparams->get_significant_params();
         $text = get_string('users');
@@ -2165,7 +2165,7 @@ class renderer extends plugin_renderer_base {
         $row->cells[] = $cell;
 
         foreach ($extrafields as $field) {
-            $row->cells[] = $this->build_header_cell(get_string($field), false, false);
+            $row->cells[] = $this->build_header_cell(\core_user\fields::get_display_name($field), false, false);
         }
 
         $rows[] = $row;

--- a/classes/structure.php
+++ b/classes/structure.php
@@ -903,6 +903,11 @@ class mod_attendance_structure {
             $users[$tempuser->studentid] = self::tempuser_to_user($tempuser);
         }
 
+        // Add custom profile field data.
+        foreach ($users as $user) {
+            profile_load_data($user);
+        }
+
         return $users;
     }
 


### PR DESCRIPTION
This change adds support for custom user profile fields:

- Ensures that the custom profile data is loaded on the report page and on the task page.
- Uses `\core_user\fields::get_display_name()` to ensure that identity field names are consistently rendered
- On the export page, excludes the custom field from extra fields since they're loaded later. This restored the expected behavior that custom fields have to be explicitly allowed for exporting by the admin. This does not affect the report page.

I can prepare a backport for 3.11.