### PR TITLE
Fix divide by zero error when viewing course summary report

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -982,7 +982,7 @@ function attendance_course_users_points($courseids = array(), $orderby = '') {
         $params = array_merge($params, $inparams);
     }
 
-    $sql = "SELECT courseid, coursename, sum(points) / sum(maxpoints) as percentage FROM (
+    $sql = "SELECT courseid, coursename, sum(points) / NULLIF(sum(maxpoints),0) as percentage FROM (
 SELECT a.id, a.course as courseid, c.fullname as coursename, atl.studentid AS userid, COUNT(DISTINCT ats.id) AS numtakensessions,
                         SUM(stg.grade) AS points, SUM(stm.maxgrade) AS maxpoints
                    FROM {attendance_sessions} ats


### PR DESCRIPTION
## Problem Description
When viewing the course summary report at the activity module level, the page errors if the points and maxpoints for the assignment activity are set to zero. SQL throws an error when dividing 0 by 0.
![image](https://user-images.githubusercontent.com/46025741/184358246-35c5ea20-cd54-413a-9253-ac4c977d021b.png)

## Resolution
Use NULLIF function to divide by null if maxpoints is zero. This will prevent the error from occurring, and the page will load as expected.
