### PR TITLE
Feature development for self reporting absence.

### DIFF
--- a/backup/moodle2/backup_attendance_stepslib.php
+++ b/backup/moodle2/backup_attendance_stepslib.php
@@ -46,7 +46,7 @@ class backup_attendance_activity_structure_step extends backup_activity_structur
 
         $statuses = new backup_nested_element('statuses');
         $status  = new backup_nested_element('status', array('id'), array(
-            'acronym', 'description', 'grade', 'studentavailability', 'setunmarked', 'visible', 'deleted', 'setnumber'));
+            'acronym', 'description', 'grade', 'studentavailability', 'availablebeforesession', 'setunmarked', 'visible', 'deleted', 'setnumber'));
 
         $warnings = new backup_nested_element('warnings');
         $warning  = new backup_nested_element('warning', array('id'), array('warningpercent', 'warnafter',

--- a/classes/form/studentattendance.php
+++ b/classes/form/studentattendance.php
@@ -56,6 +56,9 @@ class studentattendance extends \moodleform {
                 unset($statuses[$status->id]);
                 $disabledduetotime = true;
             }
+            if ($status->availablebeforesession == 0  && time() < $attforsession->sessdate) {
+                unset($statuses[$status->id]);
+            }
         }
 
         $mform->addElement('hidden', 'sessid', null);

--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -2663,6 +2663,10 @@ class renderer extends plugin_renderer_base {
             $this->output->help_icon('studentavailability', 'attendance');
         $table->align[] = 'center';
 
+        $table->head[] = get_string('availablebeforesession', 'attendance').
+            $this->output->help_icon('availablebeforesession', 'attendance');
+        $table->align[] = 'center';
+
         $table->head[] = get_string('setunmarked', 'attendance').
             $this->output->help_icon('setunmarked', 'attendance');
         $table->align[] = 'center';
@@ -2687,11 +2691,16 @@ class renderer extends plugin_renderer_base {
             $cells[] = $this->construct_text_input('description['.$st->id.']', 30, 30, $st->description) .
                                  $emptydescription;
             $cells[] = $this->construct_text_input('grade['.$st->id.']', 4, 4, $st->grade);
+            $cells[] = $this->construct_text_input('studentavailability['.$st->id.']', 4, 5, $st->studentavailability);
+            $checked = '';
+            if ($st->availablebeforesession) {
+                $checked = ' checked ';
+            }
+            $cells[] = '<input type="checkbox" name="availablebeforesession['.$st->id.']" '.$checked.'>';
             $checked = '';
             if ($st->setunmarked) {
                 $checked = ' checked ';
             }
-            $cells[] = $this->construct_text_input('studentavailability['.$st->id.']', 4, 5, $st->studentavailability);
             $cells[] = '<input type="radio" name="setunmarked" value="'.$st->id.'"'.$checked.'>';
 
             $cells[] = $this->construct_preferences_actions_icons($st, $prefdata);

--- a/db/install.xml
+++ b/db/install.xml
@@ -94,6 +94,7 @@
         <FIELD NAME="description" TYPE="char" LENGTH="30" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="grade" TYPE="number" LENGTH="5" NOTNULL="true" DEFAULT="0" SEQUENCE="false" DECIMALS="2"/>
         <FIELD NAME="studentavailability" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="How many minutes this status is available when self marking is enabled."/>
+        <FIELD NAME="availablebeforesession" TYPE="int" LENGTH="2" NOTNULL="false" SEQUENCE="false" COMMENT="Show this status before the start of a session."/>
         <FIELD NAME="setunmarked" TYPE="int" LENGTH="2" NOTNULL="false" SEQUENCE="false" COMMENT="Set this status if unmarked at end of session."/>
         <FIELD NAME="visible" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
         <FIELD NAME="deleted" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -760,5 +760,20 @@ function xmldb_attendance_upgrade($oldversion=0) {
         upgrade_mod_savepoint(true, 2022090900, 'attendance');
     }
 
+    if ($oldversion < 2023011700) {
+
+        // Define field studentavailability to be added to attendance_statuses.
+        $table = new xmldb_table('attendance_statuses');
+        $field = new xmldb_field('availablebeforesession', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'studentavailability');
+
+        // Conditionally launch add field studentavailability.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Attendance savepoint reached.
+        upgrade_mod_savepoint(true, 2023011700, 'attendance');
+    }
+
     return $result;
 }

--- a/defaultstatus.php
+++ b/defaultstatus.php
@@ -102,6 +102,7 @@ switch ($action) {
         $description    = required_param_array('description', PARAM_TEXT);
         $grade          = required_param_array('grade', PARAM_RAW);
         $studentavailability = optional_param_array('studentavailability', '0', PARAM_RAW);
+        $availablebeforesession = optional_param_array('availablebeforesession', '0', PARAM_RAW);
         $unmarkedstatus = optional_param('setunmarked', null, PARAM_INT);
         foreach ($grade as &$val) {
             $val = unformat_float($val);
@@ -117,8 +118,11 @@ switch ($action) {
             if (!isset($studentavailability[$id]) || !is_numeric($studentavailability[$id])) {
                 $studentavailability[$id] = 0;
             }
+            if (!isset($availablebeforesession[$id])) {
+                $availablebeforesession[$id] = 0;
+            }
             $errors[$id] = attendance_update_status($status, $acronym[$id], $description[$id], $grade[$id],
-                                             null, null, null, $studentavailability[$id], $setunmarked);
+                                             null, null, null, $studentavailability[$id], $availablebeforesession[$id], $setunmarked);
         }
         echo $OUTPUT->notification(get_string('eventstatusupdated', 'attendance'), 'success');
 

--- a/lang/en/attendance.php
+++ b/lang/en/attendance.php
@@ -565,6 +565,8 @@ $string['strftimeshortdate'] = '%d.%m.%Y';
 $string['studentavailability'] = 'Available for students (minutes)';
 $string['studentavailability_help'] = 'When students are marking their own attendance, the number of minutes after session starts that this status is available.
  <br/>If empty, this status will always be available, If set to 0 it will always be hidden to students.';
+ $string['availablebeforesession'] = 'Available before session start';
+$string['availablebeforesession_help'] = 'When students are marking their own attendance, allow this status to be chosen before the session begins. ';
 $string['studentid'] = 'Student ID';
 $string['studentmarked'] = 'Your attendance in this session has been recorded.';
 $string['studentmarking'] = 'Student recording';

--- a/preferences.php
+++ b/preferences.php
@@ -133,6 +133,7 @@ switch ($att->pageparams->action) {
         $description    = required_param_array('description', PARAM_TEXT);
         $grade          = required_param_array('grade', PARAM_RAW);
         $studentavailability = optional_param_array('studentavailability', null, PARAM_RAW);
+        $availablebeforesession = optional_param_array('availablebeforesession', '0', PARAM_RAW);
         $unmarkedstatus = optional_param('setunmarked', null, PARAM_INT);
 
         foreach ($grade as &$val) {
@@ -146,8 +147,11 @@ switch ($att->pageparams->action) {
             if ($unmarkedstatus == $id) {
                 $setunmarked = true;
             }
+            if (!isset($availablebeforesession[$id])) {
+                $availablebeforesession[$id] = 0;
+            }
             $errors[$id] = attendance_update_status($status, $acronym[$id], $description[$id], $grade[$id],
-                                                    null, $att->context, $att->cm, $studentavailability[$id], $setunmarked);
+                                                    null, $att->context, $att->cm, $studentavailability[$id], $availablebeforesession[$id], $setunmarked);
         }
         attendance_update_users_grade($att);
         break;

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2022111700;
+$plugin->version  = 2023011700;
 $plugin->requires = 2022090200; // Requires 4.1.
 $plugin->release = '2022111700';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
Hi,

The includes the below:

- Added checkbox to add availablebeforesession field in all the required pages. 
- If availablebeforesession is enabled in a status of a session then the global setting of studentscanmarksessiontime will be overridden for it. 
- Students can see and submit attendance for a status of a session which has availablebeforesession enabled.
- availablebeforesession allow attendance only on future sessions and not past.

**Testing instructions:**

- Create a course 
- Add activity 'attendance' to a course
- Edit setting of the activity and go to 'Status set'.
- Select 'Available Before Session' on any one or more statuses and save.
- Add a session of a future date 

Go to the course as a student and click attendance.
You will see the above selected status(es) shown here.

Regards,
Sumaiya