### PR TITLE
Feature development for self reporting absence.

### DIFF
--- a/backup/moodle2/backup_attendance_stepslib.php
+++ b/backup/moodle2/backup_attendance_stepslib.php
@@ -46,7 +46,7 @@ class backup_attendance_activity_structure_step extends backup_activity_structur
 
         $statuses = new backup_nested_element('statuses');
         $status  = new backup_nested_element('status', array('id'), array(
-            'acronym', 'description', 'grade', 'studentavailability', 'setunmarked', 'visible', 'deleted', 'setnumber'));
+            'acronym', 'description', 'grade', 'studentavailability', 'availablebeforesession', 'setunmarked', 'visible', 'deleted', 'setnumber'));
 
         $warnings = new backup_nested_element('warnings');
         $warning  = new backup_nested_element('warning', array('id'), array('warningpercent', 'warnafter',

--- a/classes/form/studentattendance.php
+++ b/classes/form/studentattendance.php
@@ -48,7 +48,7 @@ class studentattendance extends \moodleform {
         // Check if user has access to all statuses.
         $disabledduetotime = false;
         foreach ($statuses as $status) {
-            if ($status->studentavailability === '0') {
+            if ($status->studentavailability === '0' && time() > $attforsession->sessdate) {
                 unset($statuses[$status->id]);
             }
             if (!empty($status->studentavailability) &&
@@ -57,6 +57,9 @@ class studentattendance extends \moodleform {
                 $disabledduetotime = true;
             }
             if ($status->availablebeforesession == 0  && time() < $attforsession->sessdate) {
+                unset($statuses[$status->id]);
+            }
+            if ($status->availablebeforesession == 1 && time() < $attforsession->sessdate - $attforsession->studentsearlyopentime) {
                 unset($statuses[$status->id]);
             }
         }

--- a/classes/form/studentattendance.php
+++ b/classes/form/studentattendance.php
@@ -56,6 +56,9 @@ class studentattendance extends \moodleform {
                 unset($statuses[$status->id]);
                 $disabledduetotime = true;
             }
+            if ($status->availablebeforesession == 0  && time() < $attforsession->sessdate) {
+                unset($statuses[$status->id]);
+            }
         }
 
         $mform->addElement('hidden', 'sessid', null);

--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -2663,6 +2663,10 @@ class renderer extends plugin_renderer_base {
             $this->output->help_icon('studentavailability', 'attendance');
         $table->align[] = 'center';
 
+        $table->head[] = get_string('availablebeforesession', 'attendance').
+            $this->output->help_icon('availablebeforesession', 'attendance');
+        $table->align[] = 'center';
+
         $table->head[] = get_string('setunmarked', 'attendance').
             $this->output->help_icon('setunmarked', 'attendance');
         $table->align[] = 'center';
@@ -2687,11 +2691,16 @@ class renderer extends plugin_renderer_base {
             $cells[] = $this->construct_text_input('description['.$st->id.']', 30, 30, $st->description) .
                                  $emptydescription;
             $cells[] = $this->construct_text_input('grade['.$st->id.']', 4, 4, $st->grade);
+            $cells[] = $this->construct_text_input('studentavailability['.$st->id.']', 4, 5, $st->studentavailability);
+            $checked = '';
+            if ($st->availablebeforesession) {
+                $checked = ' checked ';
+            }
+            $cells[] = '<input type="checkbox" name="availablebeforesession['.$st->id.']" '.$checked.'>';
             $checked = '';
             if ($st->setunmarked) {
                 $checked = ' checked ';
             }
-            $cells[] = $this->construct_text_input('studentavailability['.$st->id.']', 4, 5, $st->studentavailability);
             $cells[] = '<input type="radio" name="setunmarked" value="'.$st->id.'"'.$checked.'>';
 
             $cells[] = $this->construct_preferences_actions_icons($st, $prefdata);

--- a/db/install.xml
+++ b/db/install.xml
@@ -94,6 +94,7 @@
         <FIELD NAME="description" TYPE="char" LENGTH="30" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="grade" TYPE="number" LENGTH="5" NOTNULL="true" DEFAULT="0" SEQUENCE="false" DECIMALS="2"/>
         <FIELD NAME="studentavailability" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="How many minutes this status is available when self marking is enabled."/>
+        <FIELD NAME="availablebeforesession" TYPE="int" LENGTH="2" NOTNULL="false" SEQUENCE="false" COMMENT="Show this status before the start of a session."/>
         <FIELD NAME="setunmarked" TYPE="int" LENGTH="2" NOTNULL="false" SEQUENCE="false" COMMENT="Set this status if unmarked at end of session."/>
         <FIELD NAME="visible" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
         <FIELD NAME="deleted" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -760,5 +760,20 @@ function xmldb_attendance_upgrade($oldversion=0) {
         upgrade_mod_savepoint(true, 2022090900, 'attendance');
     }
 
+    if ($oldversion < 2023011700) {
+
+        // Define field studentavailability to be added to attendance_statuses.
+        $table = new xmldb_table('attendance_statuses');
+        $field = new xmldb_field('availablebeforesession', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'studentavailability');
+
+        // Conditionally launch add field studentavailability.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Attendance savepoint reached.
+        upgrade_mod_savepoint(true, 2023011700, 'attendance');
+    }
+
     return $result;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -760,7 +760,7 @@ function xmldb_attendance_upgrade($oldversion=0) {
         upgrade_mod_savepoint(true, 2022090900, 'attendance');
     }
 
-    if ($oldversion < 2023011700) {
+    if ($oldversion < 2023012700) {
 
         // Define field studentavailability to be added to attendance_statuses.
         $table = new xmldb_table('attendance_statuses');
@@ -772,7 +772,7 @@ function xmldb_attendance_upgrade($oldversion=0) {
         }
 
         // Attendance savepoint reached.
-        upgrade_mod_savepoint(true, 2023011700, 'attendance');
+        upgrade_mod_savepoint(true, 2023012700, 'attendance');
     }
 
     return $result;

--- a/defaultstatus.php
+++ b/defaultstatus.php
@@ -102,6 +102,7 @@ switch ($action) {
         $description    = required_param_array('description', PARAM_TEXT);
         $grade          = required_param_array('grade', PARAM_RAW);
         $studentavailability = optional_param_array('studentavailability', '0', PARAM_RAW);
+        $availablebeforesession = optional_param_array('availablebeforesession', '0', PARAM_RAW);
         $unmarkedstatus = optional_param('setunmarked', null, PARAM_INT);
         foreach ($grade as &$val) {
             $val = unformat_float($val);
@@ -117,8 +118,11 @@ switch ($action) {
             if (!isset($studentavailability[$id]) || !is_numeric($studentavailability[$id])) {
                 $studentavailability[$id] = 0;
             }
+            if (!isset($availablebeforesession[$id])) {
+                $availablebeforesession[$id] = 0;
+            }
             $errors[$id] = attendance_update_status($status, $acronym[$id], $description[$id], $grade[$id],
-                                             null, null, null, $studentavailability[$id], $setunmarked);
+                                             null, null, null, $studentavailability[$id], $availablebeforesession[$id], $setunmarked);
         }
         echo $OUTPUT->notification(get_string('eventstatusupdated', 'attendance'), 'success');
 

--- a/lang/en/attendance.php
+++ b/lang/en/attendance.php
@@ -565,6 +565,8 @@ $string['strftimeshortdate'] = '%d.%m.%Y';
 $string['studentavailability'] = 'Available for students (minutes)';
 $string['studentavailability_help'] = 'When students are marking their own attendance, the number of minutes after session starts that this status is available.
  <br/>If empty, this status will always be available, If set to 0 it will always be hidden to students.';
+ $string['availablebeforesession'] = 'Available before session start';
+$string['availablebeforesession_help'] = 'When students are marking their own attendance, allow this status to be chosen before the session begins. ';
 $string['studentid'] = 'Student ID';
 $string['studentmarked'] = 'Your attendance in this session has been recorded.';
 $string['studentmarking'] = 'Student recording';

--- a/locallib.php
+++ b/locallib.php
@@ -428,6 +428,7 @@ function attendance_add_status($status) {
         $status->deleted = 0;
         $status->visible = 1;
         $status->setunmarked = 0;
+        $status->availablebeforesession = 0;
 
         $id = $DB->insert_record('attendance_statuses', $status);
         $status->id = $id;
@@ -487,11 +488,12 @@ function attendance_remove_status($status, $context = null, $cm = null) {
  * @param stdClass $context
  * @param stdClass $cm
  * @param int $studentavailability
+ * @param bool $availablebeforesession
  * @param bool $setunmarked
  * @return array
  */
 function attendance_update_status($status, $acronym, $description, $grade, $visible,
-                                  $context = null, $cm = null, $studentavailability = null, $setunmarked = false) {
+                                  $context = null, $cm = null, $studentavailability = null, $availablebeforesession = false, $setunmarked = false) {
     global $DB;
 
     if (empty($context)) {
@@ -528,6 +530,11 @@ function attendance_update_status($status, $acronym, $description, $grade, $visi
 
         $status->studentavailability = $studentavailability;
         $updated[] = $studentavailability;
+    }
+    if (strpos(strval($availablebeforesession), 'on') === false) {
+        $status->availablebeforesession = 0;
+    } else {
+        $status->availablebeforesession = 1;
     }
     if ($setunmarked) {
         $status->setunmarked = 1;
@@ -569,6 +576,22 @@ function attendance_random_string($length=6) {
 }
 
 /**
+ * Count the total number of statuses in a session with availablebeforesession enabled.
+ *
+ * @param int $sessionid the id in attendance_sessions.
+ * @return int
+ */
+function is_status_availablebeforesession($sessionid) {
+    global $DB;
+
+    $attendanceid = $DB->get_field_sql('SELECT attendanceid  FROM {attendance_sessions} WHERE id = ? ', array($sessionid));
+
+    $where = "deleted = 0 and visible = 1  and availablebeforesession = 1  and attendanceid = ?";
+    $params = array('attendanceid'   => $attendanceid);
+    return $DB->count_records_select('attendance_statuses', $where, $params);
+}
+
+/**
  * Check to see if this session is open for student marking.
  *
  * @param stdclass $sess the session record from attendance_sessions.
@@ -580,8 +603,10 @@ function attendance_can_student_mark($sess, $log = true) {
     $canmark = false;
     $reason = 'closed';
     $attconfig = get_config('attendance');
+
     if (!empty($attconfig->studentscanmark) && !empty($sess->studentscanmark)) {
-        if (empty($attconfig->studentscanmarksessiontime)) {
+        if (empty($attconfig->studentscanmarksessiontime) ||
+            (is_status_availablebeforesession($sess->id) > 0) && time() < $sess->sessdate) {
             $canmark = true;
             $reason = '';
         } else {

--- a/locallib.php
+++ b/locallib.php
@@ -606,7 +606,7 @@ function attendance_can_student_mark($sess, $log = true) {
 
     if (!empty($attconfig->studentscanmark) && !empty($sess->studentscanmark)) {
         if (empty($attconfig->studentscanmarksessiontime) ||
-            (is_status_availablebeforesession($sess->id) > 0) && time() < $sess->sessdate) {
+            (is_status_availablebeforesession($sess->id) > 0) && time() > $sess->sessdate - $sess->studentsearlyopentime) {
             $canmark = true;
             $reason = '';
         } else {

--- a/preferences.php
+++ b/preferences.php
@@ -133,6 +133,7 @@ switch ($att->pageparams->action) {
         $description    = required_param_array('description', PARAM_TEXT);
         $grade          = required_param_array('grade', PARAM_RAW);
         $studentavailability = optional_param_array('studentavailability', null, PARAM_RAW);
+        $availablebeforesession = optional_param_array('availablebeforesession', '0', PARAM_RAW);
         $unmarkedstatus = optional_param('setunmarked', null, PARAM_INT);
 
         foreach ($grade as &$val) {
@@ -146,8 +147,11 @@ switch ($att->pageparams->action) {
             if ($unmarkedstatus == $id) {
                 $setunmarked = true;
             }
+            if (!isset($availablebeforesession[$id])) {
+                $availablebeforesession[$id] = 0;
+            }
             $errors[$id] = attendance_update_status($status, $acronym[$id], $description[$id], $grade[$id],
-                                                    null, $att->context, $att->cm, $studentavailability[$id], $setunmarked);
+                                                    null, $att->context, $att->cm, $studentavailability[$id], $availablebeforesession[$id], $setunmarked);
         }
         attendance_update_users_grade($att);
         break;

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2022111700;
+$plugin->version  = 2023011700;
 $plugin->requires = 2022090200; // Requires 4.1.
 $plugin->release = '2022111700';
 $plugin->maturity  = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -23,9 +23,9 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2023011700;
+$plugin->version  = 2023012700;
+$plugin->release = '2023012700';
 $plugin->requires = 2022090200; // Requires 4.1.
-$plugin->release = '2022111700';
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->cron     = 0;
 $plugin->component = 'mod_attendance';


### PR DESCRIPTION

Hi,

The includes the below:

-     Added checkbox to add availablebeforesession field in all the required pages.
-     If availablebeforesession is enabled in a status of a session then the global setting of studentscanmarksessiontime will be overridden for it.
-     Students can see and submit attendance for a status of a session which has availablebeforesession enabled.
-     availablebeforesession allow attendance only on future sessions and not past.

Testing instructions:

-     Create a course
-     Add activity 'attendance' to a course
-     Edit setting of the activity and go to 'Status set'.
-     Select 'Available Before Session' on any one or more statuses and save.
-     Add a session of a future date

Go to the course as a student and click attendance.
You will see the above selected status(es) shown here.

Regards,
Sumaiya
