### PR TITLE
Hide suspended enrollments from roster by default

### DIFF
--- a/classes/structure.php
+++ b/classes/structure.php
@@ -898,6 +898,16 @@ class mod_attendance_structure {
             }
         }
 
+        // Apply filter for enrol status.
+        // We're only implementing a binary at the moment: if 1 is NOT passed,
+        // don't include suspended enrollments, otherwise we DO.
+        if ('1' != $this->pageparams->enrolstatus) {
+            // Filter suspended enrollments
+            $users = array_filter($users, function (object $user) {
+                return ($user->enrolmentstatus == 0);
+            });
+        }
+
         // Add the 'temporary' users to this list.
         $tempusers = $DB->get_records('attendance_tempusers', array('courseid' => $this->course->id));
         foreach ($tempusers as $tempuser) {

--- a/lang/en/attendance.php
+++ b/lang/en/attendance.php
@@ -120,6 +120,7 @@ $string['confirmcolumnmappings'] = 'Confirm column mappings';
 $string['confirmdeletehiddensessions'] = 'Are you sure you want to delete {$a->count} sessions scheduled before the course start date ({$a->date})?';
 $string['confirmdeleteuser'] = 'Are you sure you want to delete user \'{$a->fullname}\' ({$a->email})?<br/>All of their attendance records will be permanently deleted.';
 $string['copyfrom'] = 'Copy attendance data from';
+$string['showsuspended'] = 'Show suspended enrollments';
 $string['countofselected'] = 'Count of selected';
 $string['course'] = 'Course';
 $string['coursemessage'] = 'Message course users';

--- a/renderer.php
+++ b/renderer.php
@@ -685,6 +685,16 @@ class mod_attendance_renderer extends plugin_renderer_base {
             $controls .= $this->output->render($select);
         }
 
+        $controls .= html_writer::empty_tag('br');
+        $select = new single_select(
+            $takedata->url(array(), array('enrolstatus')),
+            'enrolstatus',
+            ['0' => get_string('no'), '1' => get_string('yes')],
+            $takedata->pageparams->enrolstatus);
+        $select->set_label(get_string('showsuspended', 'attendance'));
+        $select->class = 'singleselect inline';
+        $controls .= $this->output->render($select);
+
         return $controls;
     }
 

--- a/take.php
+++ b/take.php
@@ -36,6 +36,7 @@ $pageparams->viewmode   = optional_param('viewmode', null, PARAM_INT);
 $pageparams->gridcols   = optional_param('gridcols', null, PARAM_INT);
 $pageparams->page       = optional_param('page', 1, PARAM_INT);
 $pageparams->perpage    = optional_param('perpage', get_config('attendance', 'resultsperpage'), PARAM_INT);
+$pageparams->enrolstatus = optional_param('enrolstatus', '0', PARAM_INT);
 
 $cm             = get_coursemodule_from_id('attendance', $id, 0, false, MUST_EXIST);
 $course         = $DB->get_record('course', array('id' => $cm->course), '*', MUST_EXIST);


### PR DESCRIPTION
Implements a simple enrolment status filtering mechanism to hide suspended enrollments from the roster by default. Implements a simple UI dropdown to enable normal behavior.

Very likely should be enhanced via some sort of admin setting to adjust default behavior if desired.

This patch does not provide any Behat tests and applies only to the 3.11 branch. Merging to Moodle 4 branch will require more work.

The lack of this functionality was causing a lot of frustration for instructors at my institution since we suspend enrollments instead of unenrolling (for various reasons) so this is a quick-and-dirty implementation to work around this.