### PR TITLE
fixed event data not containing attendance_log id

### DIFF
--- a/classes/structure.php
+++ b/classes/structure.php
@@ -714,7 +714,7 @@ class mod_attendance_structure {
             $record->id = $existingattendance;
             $logid = $DB->update_record('attendance_log', $record, false);
         } else {
-            $logid = $DB->insert_record('attendance_log', $record, false);
+            $logid = $DB->insert_record('attendance_log', $record);
             $record->id = $logid;
         }
 


### PR DESCRIPTION
It looks like it was originally intended to work like this. Before with `false` being passed you'd only get back a boolean, usually `true` instead of the id of the database record.