### PR TITLE
ATT-698 Fix deleting when enablecalendar is off

### DIFF
--- a/classes/calendar_helpers.php
+++ b/classes/calendar_helpers.php
@@ -175,7 +175,7 @@ function attendance_delete_calendar_events($sessionsids) {
  */
 function attendance_existing_calendar_events_ids($sessionsids) {
     global $DB;
-    $caleventsids = array_keys($DB->get_records_list('attendance_sessions', 'id', $sessionsids, '', 'caleventid'));
+    $caleventsids = array_keys($DB->get_records_list('attendance_sessions', 'id', $sessionsids, '', 'DISTINCT caleventid'));
     $existingcaleventsids = array_filter($caleventsids);
     if (! empty($existingcaleventsids)) {
         return $existingcaleventsids;


### PR DESCRIPTION
This fixes #698  -  See that writeup for more information, but the essence of the issue is:

- Turn off `enablecalendar`
- Create an Attendance and add multiple sessions
- Delete the attendance
- Error shows in cron.php

This is because all `caleventid` values are zero if `enablecalendar` is false. An error occurs because instead of unique values for `caleventid` to construct the array in `attendance_existing_calendar_events_ids()`, you receive duplicate values for the keys (zero), so it complains.

## This Fix
This adds the `DISTINCT` keyword, which returns only one zero when `enablecalendar` is off, and all of the distinct entries when it's one. There are other ways to fix this, of course, but this seemed to introduce the least amount of change.