### PR TITLE
Add perpage property to page_with_filter_controls

### DIFF
--- a/classes/page_with_filter_controls.php
+++ b/classes/page_with_filter_controls.php
@@ -62,6 +62,9 @@ class mod_attendance_page_with_filter_controls {
     /** @var int type. */
     public $selectortype        = self::SELECTOR_NONE;
 
+    /** @var int number of items per page */
+    public $perpage;
+
     /** @var int default view. */
     protected $defaultview;
 


### PR DESCRIPTION
To avoid the PHP 8.2 deprecation of dynamic properties, the simple fix was to add the needed property to the page_with_filter_controls class.

Fixes #724 