### PR TITLE
fixed JS typos for bulk mark links

### DIFF
--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -800,7 +800,7 @@ class renderer extends plugin_renderer_base {
             $row->cells[] = html_writer::empty_tag('input', $attribs);
             // Select all radio buttons of the same status.
             $this->page->requires->js_amd_inline("
-                require(['jquery', 'core_user/repository], function($, UserRepository) {
+                require(['jquery', 'core_user/repository'], function($, UserRepository) {
                     $('#radiocheckstatus".$st->id."').click(function(e) {
                         if ($('select[name=\"setallstatus-select\"] option:selected').val() == 'all') {
                             $('#attendancetakeform').find('.st".$st->id."').prop('checked', true);
@@ -873,7 +873,7 @@ class renderer extends plugin_renderer_base {
                                               'title' => get_string('setallstatusesto', 'attendance', $st->description)));
             // JS to select all radios of this status and prevent default behaviour of # link.
             $this->page->requires->js_amd_inline("
-                 require(['jquery', 'core_user/repository], function($, UserRepository) {
+                 require(['jquery', 'core_user/repository'], function($, UserRepository) {
                      $('#checkstatus".$st->id."').click(function(e) {
                          if ($('select[name=\"setallstatus-select\"] option:selected').val() == 'unselected') {
                              $('#attendancetakeform').find('input:indeterminate.st".$st->id."').prop('checked', true);


### PR DESCRIPTION
My apologies...!
I forgot a single quotation mark in my previous fix which prevents JavaScript from running properly, now fixed.
This will fix #722.
