### PR TITLE
Use Server Time when rotating QR Codes

### DIFF
--- a/js/password/attendance_QRCodeRotate.js
+++ b/js/password/attendance_QRCodeRotate.js
@@ -13,12 +13,15 @@ class attendance_QRCodeRotate {
         this.password = "";
         this.qrCodeInstance = "";
         this.qrCodeHTMLElement = "";
+        this.timeOffset = new Date();
     }
 
-    start(sessionId, qrCodeHTMLElement, timerHTMLElement) {
+    start(sessionId, qrCodeHTMLElement, timerHTMLElement, serverTime) {
         this.sessionId = sessionId;
         this.qrCodeHTMLElement = qrCodeHTMLElement;
         this.timerHTMLElement = timerHTMLElement;
+        this.timeOffset = new Date() - new Date(serverTime * 1000);
+        console.log(`Sync OK - Server time is ${new Date(serverTime * 1000)}\nClient's time is ${this.timeOffset < 0 ? 'late' : 'early'} by ${Math.abs(this.timeOffset)} milliseconds.`);
         this.fetchAndRotate();
     }
 
@@ -43,13 +46,17 @@ class attendance_QRCodeRotate {
         this.timerHTMLElement.innerHTML = timeLeft;
     }
 
+    serverTime() {
+        return Math.round((new Date().getTime() - this.timeOffset) / 1000);
+    }
+
     startRotating() {
         var parent = this;
 
         setInterval(function() {
             var found = Object.values(parent.password).find(function(element) {
 
-                if (element.expirytime > Math.round(new Date().getTime() / 1000)) {
+                if (element.expirytime > parent.serverTime()) {
                     return element;
                 }
             });
@@ -58,7 +65,7 @@ class attendance_QRCodeRotate {
                 location.reload(true);
             } else {
                 parent.changeQRCode(found.password);
-                parent.updateTimer(found.expirytime - Math.round(new Date().getTime() / 1000));
+                parent.updateTimer(found.expirytime - parent.serverTime());
 
             }
 

--- a/locallib.php
+++ b/locallib.php
@@ -1438,7 +1438,7 @@ function attendance_renderqrcoderotate($session) {
     echo '
     <script type="text/javascript">
         let qrCodeRotate = new attendance_QRCodeRotate();
-        qrCodeRotate.start(' . $session->id . ', document.getElementById("qrcode"), document.getElementById("rotate-time"));
+        qrCodeRotate.start(' . $session->id . ', document.getElementById("qrcode"), document.getElementById("rotate-time"), '. time() .');
     </script>';
 }
 


### PR DESCRIPTION
This is my first contribution to Moodle, so please don't hesitate to correct me on any coding standard issues.

I have made a quick patch to rotating QR codes, so that the client's browser gets the server time, and rotates QR Codes using that. 
We've had repeated issues stemming from the teachers' machines not being in sync with our Moodle server, this PR fixes that: It doesn't matter what the client's clock is anymore.

I will submit this patch to Moode 3.X as well - that is what we still use and what I made first, but I ported the fix to the latest branch too (#734).