### PR TITLE
Use Server Time when rotating QR Codes (Moodle 3.11.X)

### DIFF
--- a/js/password/attendance_QRCodeRotate.js
+++ b/js/password/attendance_QRCodeRotate.js
@@ -15,11 +15,13 @@ class attendance_QRCodeRotate {
         this.qrCodeHTMLElement = "";
     }
 
-    start(sessionId, qrCodeHTMLElement, textPasswordHTMLElement, timerHTMLElement) {
+    start(sessionId, qrCodeHTMLElement, textPasswordHTMLElement, timerHTMLElement, serverTime) {
         this.sessionId = sessionId;
         this.qrCodeHTMLElement = qrCodeHTMLElement;
         this.textPasswordHTMLElement = textPasswordHTMLElement;
         this.timerHTMLElement = timerHTMLElement;
+        this.timeOffset = new Date() - new Date(serverTime * 1000);
+        console.log(`Sync OK - Server time is ${new Date(serverTime * 1000)}\nClient's time is ${this.timeOffset < 0 ? 'late' : 'early'} by ${Math.abs(this.timeOffset)} milliseconds.`);
         this.fetchAndRotate();
     }
 
@@ -46,13 +48,17 @@ class attendance_QRCodeRotate {
         this.timerHTMLElement.innerHTML = '<h3>Time left: '+timeLeft+'</h3>';
     }
 
+    serverTime() {
+        return Math.round((new Date().getTime() - this.timeOffset) / 1000);
+    }
+
     startRotating() {
         var parent = this;
 
         setInterval(function() {
             var found = Object.values(parent.password).find(function(element) {
 
-                if (element.expirytime > Math.round(new Date().getTime() / 1000)) {
+                if (element.expirytime > parent.serverTime()) {
                     return element;
                 }
             });
@@ -61,7 +67,7 @@ class attendance_QRCodeRotate {
                 location.reload(true);
             } else {
                 parent.changeQRCode(found.password);
-                parent.updateTimer(found.expirytime - Math.round(new Date().getTime() / 1000));
+                parent.updateTimer(found.expirytime - parent.serverTime());
 
             }
 

--- a/locallib.php
+++ b/locallib.php
@@ -1377,7 +1377,7 @@ function attendance_renderqrcoderotate($session) {
     <script type="text/javascript">
         let qrCodeRotate = new attendance_QRCodeRotate();
         qrCodeRotate.start(' . $session->id . ', document.getElementById("qrcode"), document.getElementById("text-password"),
-        document.getElementById("rotate-time"));
+        document.getElementById("rotate-time"), '. time() .');
     </script>';
 }
 


### PR DESCRIPTION
This is my first contribution to Moodle, so please don't hesitate to correct me on any coding standard issues.

I have made a quick patch to rotating QR codes, so that the client's browser gets the server time, and rotates QR Codes using that.
We've had repeated issues stemming from the teachers' machines not being in sync with our Moodle server, this PR fixes that: It doesn't matter what the client's clock is anymore.

I have submitted this patch to Moode 4.X as well - we still use 3.X and that is what I made first, but I ported the fix to the latest branch too (#733).