### PR TITLE
Type notice on installation

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -1255,7 +1255,7 @@ function attendance_get_automarkoptions() {
         $options[ATTENDANCE_AUTOMARK_ALL] = get_string('automarkall', 'attendance');
     }
     $options[ATTENDANCE_AUTOMARK_CLOSE] = get_string('automarkclose', 'attendance');
-    if ($COURSE == SITEID || $COURSE->enablecompletion == COMPLETION_ENABLED) {
+    if ($COURSE->id == SITEID || $COURSE->enablecompletion == COMPLETION_ENABLED) {
         $options[ATTENDANCE_AUTOMARK_ACTIVITYCOMPLETION] = get_string('onactivitycompletion', 'attendance');
     }
 


### PR DESCRIPTION
On installation with PHP 8.1 I'm seeing this message: `Notice: Object of class stdClass could not be converted to int in /var/www/html/mod/attendance/locallib.php on line 1258`

It looks like the $COURSE->id should be used for comparison with SITEID instead of the whole object.