### PR TITLE
Remove special chars from acronym fieldnames #752

### DIFF
--- a/classes/local/entities/attendance.php
+++ b/classes/local/entities/attendance.php
@@ -739,7 +739,7 @@ class attendance extends base {
      * @return array
      */
     private function acronymfieldnames(string $acronym): array {
-        $fieldname = 'status_' . strtolower($acronym) . '_total_count';
+        $fieldname = 'status_' . rtrim(base64_encode($acronym), '=') . '_total_count';
         return [
             $fieldname,
             $fieldname . '_current_week',


### PR DESCRIPTION
This small change encodes the acronym field names in base64 (removing trailing equals) to fix https://github.com/danmarsden/moodle-mod_attendance/issues/752, where acronyms with special characters cause an issue because reportbuilder requires that filters and columns be alphanumeric. This keeps acronym names unique while removing special characters.

It does require removing the strtolower() call, since base64 uses both upper and lower case letters -- I hope that isn't an issue. Everything worked well when testing.