### PR TITLE
add course category to custom report

### DIFF
--- a/classes/reportbuilder/datasource/attendance.php
+++ b/classes/reportbuilder/datasource/attendance.php
@@ -19,7 +19,8 @@ declare(strict_types=1);
 namespace mod_attendance\reportbuilder\datasource;
 
 use core_reportbuilder\datasource;
-use core_reportbuilder\local\entities\course;;
+use core_reportbuilder\local\entities\course;
+use core_course\reportbuilder\local\entities\course_category;
 use core_reportbuilder\local\entities\user;
 use core_reportbuilder\local\helpers\database;
 
@@ -64,10 +65,18 @@ class attendance extends datasource {
         $userjoin = "JOIN {user} {$useralias} ON {$useralias}.id = {$attendancelogalias}.studentid";
         $this->add_entity($userentity->add_join($userjoin));
 
+        // Join the course entity.
         $coursentity = new course();
         $coursealias = $coursentity->get_table_alias('course');
         $coursejoin = "JOIN {course} {$coursealias} ON {$coursealias}.id = {$attendancealias}.course";
         $this->add_entity($coursentity->add_join($coursejoin));
+
+        // Join the course category entity.
+        $coursecatentity = new course_category();
+        $coursecattablealias = $coursecatentity->get_table_alias('course_categories');
+        $this->add_entity($coursecatentity
+            ->add_join("JOIN {course_categories} {$coursecattablealias}
+                ON {$coursecattablealias}.id = {$coursealias}.category"));
 
         $this->add_all_from_entities();
     }


### PR DESCRIPTION
Could you please add the course category entity to the Attendance custom report so users can add category info to their report? Most importantly filter courses by their categories as they often represent departments, colleges, and schools. This would be beneficial for everyone.