### PR TITLE
add a button to display text password with qrcode

### DIFF
--- a/js/password/attendance_QRCodeRotate.js
+++ b/js/password/attendance_QRCodeRotate.js
@@ -16,9 +16,10 @@ class attendance_QRCodeRotate {
         this.timeOffset = new Date();
     }
 
-    start(sessionId, qrCodeHTMLElement, timerHTMLElement, serverTime) {
+    start(sessionId, qrCodeHTMLElement, textPasswordHTMLElement, timerHTMLElement, serverTime) {
         this.sessionId = sessionId;
         this.qrCodeHTMLElement = qrCodeHTMLElement;
+        this.textPasswordHTMLElement = textPasswordHTMLElement;
         this.timerHTMLElement = timerHTMLElement;
         this.timeOffset = new Date() - new Date(serverTime * 1000);
         console.log(`Sync OK - Server time is ${new Date(serverTime * 1000)}\nClient's time is ${this.timeOffset < 0 ? 'late' : 'early'} by ${Math.abs(this.timeOffset)} milliseconds.`);
@@ -40,6 +41,8 @@ class attendance_QRCodeRotate {
         var qrcodeurl = document.URL.substr(0,document.URL.lastIndexOf('/')) + '/attendance.php?qrpass=' + password + '&sessid=' + this.sessionId;
         this.qrCodeInstance.clear();
         this.qrCodeInstance.makeCode(qrcodeurl);
+        // display new password
+        this.textPasswordHTMLElement.innerHTML = '<h2>'+password+'</h2>';
     }
 
     updateTimer(timeLeft) {

--- a/lang/en/attendance.php
+++ b/lang/en/attendance.php
@@ -541,6 +541,7 @@ $string['showqrcode'] = 'Show QR code';
 $string['showsessiondescriptiononreport'] = 'Show session description in report';
 $string['showsessiondescriptiononreport_desc'] = 'Show the session description in the attendance report listing.';
 $string['showsessiondetails'] = 'Show session details';
+$string['showtextpassword'] = 'Show password';
 $string['somedisabledstatus'] = '(Some options have been removed as the session has started.)';
 $string['sortedgrid'] = 'Sorted grid';
 $string['sortedlist'] = 'Sorted list';

--- a/locallib.php
+++ b/locallib.php
@@ -1437,11 +1437,20 @@ function attendance_renderqrcoderotate($session) {
     echo html_writer::div(get_string('qrcodevalidbefore', 'attendance').' '.
                           html_writer::span('0', '', ['id' => 'rotate-time']).' '
                           .get_string('qrcodevalidafter', 'attendance'), 'qrcodevalid'); // Div to display timer.
+    echo html_writer::tag('button', get_string('showtextpassword', 'attendance'),
+        [
+            'class' => 'btn btn-primary',
+            'data-toggle' => 'collapse',
+            'data-target' => '#text-password'
+        ]
+    );
+    echo html_writer::tag('div', '', ['id' => 'text-password', 'class' => 'collapse']); // Button to display text-password
     // Js to start the password manager.
     echo '
     <script type="text/javascript">
         let qrCodeRotate = new attendance_QRCodeRotate();
-        qrCodeRotate.start(' . $session->id . ', document.getElementById("qrcode"), document.getElementById("rotate-time"), '. time() .');
+        qrCodeRotate.start(' . $session->id . ', document.getElementById("qrcode"), document.getElementById("text-password"),
+        document.getElementById("rotate-time"), '. time() .');
     </script>';
 }
 


### PR DESCRIPTION
Hello,

Here is a proposal to fix [#713](https://github.com/danmarsden/moodle-mod_attendance/issues/713) (Display raw password and QR code at same time.).

I added a collapse button to show the text password below the QR code if needed.

![Capture d’écran du 2024-09-27 09-45-30](https://github.com/user-attachments/assets/8088a318-67f8-46ef-81f6-67d33fd3fa3f)
