### PR TITLE
Remove hardcoded prefix

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -643,7 +643,7 @@ function xmldb_attendance_upgrade($oldversion=0) {
         $sql = "modulename = 'attendance' AND NOT EXISTS (
                     SELECT 1
                     FROM {attendance_sessions} a
-                    WHERE mdl_event.id = a.caleventid
+                    WHERE {event}.id = a.caleventid
                 )";
         $DB->delete_records_select('event', $sql);
 


### PR DESCRIPTION
Recently I had to upgrade an old version of this plugin and faced issues (upgrade crash) due to this hardcoded prefix.
