### PR TITLE
Fixes #808. Allow taking of attendance for non-participation groups.

### DIFF
--- a/take.php
+++ b/take.php
@@ -54,7 +54,8 @@ $pageparams->init($course->id);
 $att = new mod_attendance_structure($att, $cm, $course, $PAGE->context, $pageparams);
 
 $allowedgroups = groups_get_activity_allowed_groups($cm);
-if (!empty($pageparams->grouptype) && !array_key_exists($pageparams->grouptype, $allowedgroups)) {
+$accessallgroups = has_capability('moodle/site:accessallgroups', $context);
+if (!$accessallgroups && !empty($pageparams->grouptype) && !array_key_exists($pageparams->grouptype, $allowedgroups)) {
      $group = groups_get_group($pageparams->grouptype);
      throw new moodle_exception('cannottakeforgroup', 'attendance', '', $group->name);
 }


### PR DESCRIPTION
This patch fixes issue #808 by allowing users with the "moodle/site:accessallgroups" capability on the attendance activity to take attendance for any group.