### PR TITLE
Remove sesskey from redirects

### DIFF
--- a/attendance.php
+++ b/attendance.php
@@ -149,7 +149,7 @@ if (!empty($qrpass) && !empty($attforsession->autoassignstatus) && attendance_se
     if (!empty($attforsession->studentpassword) &&
         $attforsession->studentpassword !== $qrpass) {
 
-        $url = new moodle_url('/mod/attendance/attendance.php', ['sessid' => $id, 'sesskey' => sesskey()]);
+        $url = new moodle_url('/mod/attendance/attendance.php', ['sessid' => $id]);
         redirect($url, get_string('incorrectpassword', 'mod_attendance'), null, \core\output\notification::NOTIFY_ERROR);
     }
 
@@ -202,7 +202,7 @@ if ($mform->is_cancelled()) {
         // Check if password being passed is valid.
         && $attforsession->studentpassword !== $fromform->studentpassword) {
 
-        $url = new moodle_url('/mod/attendance/attendance.php', ['sessid' => $id, 'sesskey' => sesskey()]);
+        $url = new moodle_url('/mod/attendance/attendance.php', ['sessid' => $id]);
         redirect($url, get_string('incorrectpassword', 'mod_attendance'), null, \core\output\notification::NOTIFY_ERROR);
     }
     if (attendance_session_open_for_students($attforsession) && $attforsession->autoassignstatus) {

--- a/tests/behat/attendance_mod.feature
+++ b/tests/behat/attendance_mod.feature
@@ -64,6 +64,34 @@ Feature: Teachers and Students can record session attendance
     Then "Attendance taken by student" "link" should exist
 
   @javascript
+  Scenario: Students can be required to enter a password when recording own attendance
+    Given I am on the "Attendance" "mod_attendance > View" page logged in as "teacher1"
+    And I click on "Add session" "button"
+    And I set the field "Allow students to record own attendance" to "1"
+    And I set the field "studentpassword" to "1234"
+    And I set the following fields to these values:
+      | id_sestime_starthour | 00 |
+      | id_sestime_endhour   | 23 |
+      | id_sestime_endminute | 55 |
+    And I click on "id_submitbutton" "button"
+    And I log out
+    And I am on the "Attendance" "mod_attendance > View" page logged in as "student1"
+    And I follow "Submit attendance"
+    When I set the field "Present" to "1"
+    And I press "Save changes"
+    And I should see "You must enter the session password"
+    And I should not see "Self-recorded"
+    And I set the field "Password" to "1235"
+    And I set the field "Present" to "1"
+    And I press "Save changes"
+    And I should see "You have entered an incorrect password"
+    And I should not see "Self-recorded"
+    And I set the field "Password" to "1234"
+    And I set the field "Present" to "1"
+    And I press "Save changes"
+    Then I should see "Self-recorded"
+
+  @javascript
   Scenario: If allowed, students can mark their own attendance before the session starts and teacher can choose which statuses are available.
     Given I am on the "Attendance" "mod_attendance > View" page logged in as "teacher1"
     And I click on "Add session" "button"

--- a/tests/behat/extra_features.feature
+++ b/tests/behat/extra_features.feature
@@ -71,6 +71,7 @@ Feature: Test the various new features in the attendance module
   @javascript
   Scenario: A teacher can take attendance for temporary users
     Given I am on the "Test attendance" "mod_attendance > View" page logged in as "teacher1"
+    And I change viewport size to "large"
     And I click on "More" "link" in the ".secondary-navigation" "css_element"
     And I select "Temporary users" from secondary navigation
     And I set the following fields to these values:


### PR DESCRIPTION
Resolves issue #821. I have included a behat test to cover the password feature, and confirm that re-submitting the attendance form works after a redirect, without the inclusion of the sesskey.

I will create companion PRs for the other stable branches.