### PR TITLE
Fix stored XSS in attendance remarks affecting teacher & student data

### DIFF
--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -1363,7 +1363,7 @@ class renderer extends plugin_renderer_base {
                 $row->cells[] = $status->description.$updatelink;
                 $row->cells[] = format_float($status->grade, 1, true, true) . ' / ' .
                                     format_float($statussetmaxpoints[$status->setnumber], 1, true, true);
-                $row->cells[] = $sess->remarks;
+                $row->cells[] = s($sess->remarks);
             } else if (($sess->sessdate + $sess->duration) < $userdata->user->enrolmentstart) {
                 $cell = new html_table_cell(get_string('enrolmentstart', 'attendance',
                                             userdate($userdata->user->enrolmentstart, '%d.%m.%Y')));
@@ -1993,7 +1993,7 @@ class renderer extends plugin_renderer_base {
                         $cell = new html_table_cell($celltext);
                         $row->cells[] = $cell;
 
-                        $celltext = empty($ucdata['remarks']) ? '' : $ucdata['remarks'];
+                        $celltext = empty($ucdata['remarks']) ? '' : s($ucdata['remarks']); // Protect against XSS https://moodledev.io/general/development/policies/security/crosssite-scripting#escaping-output
                         $cell = new html_table_cell($celltext);
                         $row->cells[] = $cell;
 
@@ -2001,7 +2001,7 @@ class renderer extends plugin_renderer_base {
                         if (!empty($sess->statusid)) {
                             $status = $userdata->statuses[$sess->attendanceid][$sess->statusid];
                             $row->cells[] = $status->description;
-                            $row->cells[] = $sess->remarks;
+                            $row->cells[] = s($sess->remarks);
                         }
                     }
 
@@ -2011,7 +2011,7 @@ class renderer extends plugin_renderer_base {
                         $row->cells[] = $status->description;
                         $row->cells[] = format_float($status->grade, 1, true, true) . ' / ' .
                             format_float($statussetmaxpoints[$status->setnumber], 1, true, true);
-                        $row->cells[] = $sess->remarks;
+                        $row->cells[] = s($sess->remarks);
                     } else if (($sess->sessdate + $sess->duration) < $userdata->user->enrolmentstart) {
                         $cell = new html_table_cell(get_string('enrolmentstart', 'attendance',
                         userdate($userdata->user->enrolmentstart, '%d.%m.%Y')));

--- a/renderhelpers.php
+++ b/renderhelpers.php
@@ -248,7 +248,7 @@ class user_sessions_cells_html_generator extends user_sessions_cells_generator {
 
         // Format the remark.
         $icon = $OUTPUT->pix_icon('i/info', '');
-        $remark = html_writer::span($text, 'remarkcontent');
+        $remark = html_writer::span(s($text), 'remarkcontent'); // Protect against XSS https://moodledev.io/general/development/policies/security/crosssite-scripting#escaping-output
         $remark = html_writer::span($icon.$remark, 'remarkholder');
 
         // Add it into the previous cell.


### PR DESCRIPTION
## Summary

This PR fixes a stored Cross-Site Scripting (XSS) vulnerability in the Attendance module where user-controlled remarks are rendered without proper escaping in multiple report views.

Affected code paths:
- `renderhelpers.php` – `construct_remarks_cell()` rendered raw `$text` inside HTML.
- `classes/output/renderer.php` – several occurrences where `$ucdata['remarks']` and `$sess->remarks` are directly inserted into table cells.

Since remarks can be entered by users with limited privileges but are later viewed by teachers and potentially administrators, this is a classic stored XSS scenario.

These changes follow Moodle’s own XSS guidance (escape on output using s() / context-appropriate helpers) ([source](https://moodledev.io/general/development/policies/security/crosssite-scripting#escaping-output)).