### PR TITLE
Fix #863 - Load data for custom field textareas when editing session.

### DIFF
--- a/classes/customfield/session_handler.php
+++ b/classes/customfield/session_handler.php
@@ -179,30 +179,6 @@ class session_handler extends \core_customfield\handler {
     }
 
     /**
-     * Attendance session form a bit non-standard, use custom function to populate array of existing data.
-     *
-     * Example:
-     *   $instance = $DB->get_record(...);
-     *   // .... prepare editor, filemanager, add tags, etc.
-     *   $handler->instance_form_before_set_data($instance);
-     *   $form->set_data($instance);
-     *
-     * @param array $instance the instance that has custom fields, if 'id' attribute is present the custom
-     *    fields for this instance will be added, otherwise the default values will be added.
-     * @return array
-     */
-    public function instance_form_before_set_data_array(array $instance) {
-        $instanceid = !empty($instance['id']) ? $instance['id'] : 0;
-        $fields = api::get_instance_fields_data($this->get_editable_fields($instanceid), $instanceid);
-
-        foreach ($fields as $formfield) {
-            foreach ($fields as $formfield) {
-                $instance[$formfield->get_form_element_name()] = $formfield->get_value();
-            }
-        }
-        return $instance;
-    }
-    /**
      * Get list of custom fields that contain data in this attendance activity (hides fields that do not store anything)
      *
      * @param int $instanceid id of the record to get the context for

--- a/classes/form/updatesession.php
+++ b/classes/form/updatesession.php
@@ -60,6 +60,7 @@ class updatesession extends \moodleform {
         $endminute = floor(($endtime - $endhour * HOURSECS) / MINSECS);
 
         $data = [
+            'id' => $sess->id,
             'sessiondate' => $sess->sessdate,
             'sestime' => ['starthour' => $starthour, 'startminute' => $startminute,
             'endhour' => $endhour, 'endminute' => $endminute, ],
@@ -239,9 +240,10 @@ class updatesession extends \moodleform {
         // Add custom field data to form.
         $handler = \mod_attendance\customfield\session_handler::create();
         $handler->instance_form_definition($mform, $sess->id);
-        $data['id'] = $sess->id;
-        $data = $handler->instance_form_before_set_data_array($data);
-
+        $instance = new \stdClass();
+        $instance->id = $sess->id;
+        $handler->instance_form_before_set_data($instance);
+        $data = array_merge($data, (array) $instance);
         $mform->setDefaults($data);
         $this->add_action_buttons(true);
     }


### PR DESCRIPTION
note - this change seems to break tiny editor when editing a session - it shows in plain text - not sure why yet.