### PR TITLE
added course wise support for students marking attendance after session time

### DIFF
--- a/classes/structure.php
+++ b/classes/structure.php
@@ -75,6 +75,9 @@ class mod_attendance_structure {
     /** @var string subnets (IP range) for student self selection. */
     public $subnet;
 
+    /** @var bool flag set when students can mark after session time. */
+    public $studentscanmarkaftersessiontime;
+
     /** @var string subnets (IP range) for student self selection. */
     public $automark;
 

--- a/db/install.xml
+++ b/db/install.xml
@@ -14,6 +14,7 @@
         <FIELD NAME="intro" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="This field is a requirement for activity modules."/>
         <FIELD NAME="introformat" TYPE="int" LENGTH="4" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="This field is a requirement for activity modules."/>
         <FIELD NAME="subnet" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="Default subnet used when creating sessions."/>
+        <FIELD NAME="studentscanmarkaftersessiontime" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="Allow students to mark attendance after session time."/>
         <FIELD NAME="sessiondetailspos" TYPE="char" LENGTH="5" NOTNULL="true" DEFAULT="left" SEQUENCE="false" COMMENT="Position for the session detail columns related to summary columns."/>
         <FIELD NAME="showsessiondetails" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Define if session details should be shown in reports."/>
         <FIELD NAME="showextrauserdetails" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Define if extra user details should be shown in reports."/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -860,5 +860,19 @@ function xmldb_attendance_upgrade($oldversion = 0) {
         upgrade_mod_savepoint(true, 2023032800, 'attendance');
     }
 
+    if ($oldversion < 2026010600) {
+        // Define field studentscanmarkaftersessiontime to be added to attendance.
+        $table = new xmldb_table('attendance');
+        $field = new xmldb_field('studentscanmarkaftersessiontime', XMLDB_TYPE_INTEGER, '1', null, null, null, null, 'subnet');
+
+        // Conditionally launch add field studentavailability.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Attendance savepoint reached.
+        upgrade_mod_savepoint(true, 2026010600, 'attendance');
+    }
+
     return true;
 }

--- a/lang/en/attendance.php
+++ b/lang/en/attendance.php
@@ -383,6 +383,7 @@ $string['numsessionstaken'] = 'Number of sessions taken';
 $string['olddate'] = 'Old date';
 $string['onactivitycompletion'] = 'On activity completion';
 $string['onlyselectedusers'] = 'Export specific users';
+$string['otheroptions'] = 'Other options';
 $string['overallsessions'] = 'Over all sessions';
 $string['overallsessions_help'] = 'Shows statistics for all sessions including those not yet taken (past and future):
 <ul>
@@ -605,6 +606,8 @@ $string['studentscanmarksessiontime'] = 'Students record attendance during sessi
 $string['studentscanmarksessiontime_desc'] = 'If checked students can only record their attendance during the session.';
 $string['studentscanmarksessiontimeend'] = 'Session end (minutes)';
 $string['studentscanmarksessiontimeend_desc'] = 'If the session does not have an end time, how many minutes should the session be available for students to record their attendance.';
+$string['studentscanmarkaftersessiontime'] = 'Students record attendance after session time';
+$string['studentscanmarkaftersessiontime_help'] = 'If checked students can record their attendance after the session has ended.';
 $string['studentsearlyopentime'] = 'Open session early for marking';
 $string['studentsearlyopentime_help'] = 'This allows teachers to open the session early, alowing for attendance to be taken before the real start time.';
 $string['submit'] = 'Submit';

--- a/lib.php
+++ b/lib.php
@@ -112,6 +112,8 @@ function attendance_add_instance($attendance) {
         $attendance->grade = 100;
     }
 
+    $attendance->studentscanmarkaftersessiontime = !isset($attendance->studentscanmarkaftersessiontime) ? null : 1;
+
     $attendance->id = $DB->insert_record('attendance', $attendance);
 
     att_add_default_statuses($attendance->id);
@@ -133,7 +135,8 @@ function attendance_update_instance($attendance) {
     global $DB;
 
     $attendance->timemodified = time();
-    $attendance->id = $attendance->instance;
+    $attendance->id = $attendance->instance;    
+    $attendance->studentscanmarkaftersessiontime = !isset($attendance->studentscanmarkaftersessiontime) ? null : 1;
 
     if (! $DB->update_record('attendance', $attendance)) {
         return false;

--- a/locallib.php
+++ b/locallib.php
@@ -659,8 +659,12 @@ function attendance_can_student_mark($sess, $log = true) {
     $attconfig = get_config('attendance');
 
     if (!empty($attconfig->studentscanmark) && !empty($sess->studentscanmark)) {
+        $attendanceid = $DB->get_field('attendance_sessions', 'attendanceid', ['id' => $sess->id]);
+        $attendance = $DB->get_record('attendance', ['id' => $attendanceid]);
+
         if (
             empty($attconfig->studentscanmarksessiontime) ||
+            ! empty( $attendance->studentscanmarkaftersessiontime ) ||
             (attendance_is_status_availablebeforesession($sess->id)) && time() < $sess->sessdate
         ) {
             $canmark = true;

--- a/mod_form.php
+++ b/mod_form.php
@@ -70,6 +70,10 @@ class mod_attendance_mod_form extends moodleform_mod {
             $mform->setType('subnet', PARAM_TEXT);
         }
 
+        $mform->addElement('header', 'otheroptions', get_string('otheroptions', 'attendance'));
+        $mform->addElement('checkbox', 'studentscanmarkaftersessiontime', get_string('studentscanmarkaftersessiontime', 'attendance'));
+        $mform->addHelpButton('studentscanmarkaftersessiontime', 'studentscanmarkaftersessiontime', 'attendance');
+
         $this->add_action_buttons();
     }
 }

--- a/version.php
+++ b/version.php
@@ -23,8 +23,8 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2025122100;
-$plugin->release = 2025111100;
+$plugin->version  = 2026010600;
+$plugin->release = 2026010600;
 $plugin->requires = 2025031100; // Requires 5.0.
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->cron     = 0;


### PR DESCRIPTION
By default, there is a single global check in plugin settings to allow students to mark attendance within session time. With this feature, there is a course level support to allow students to mark attendance after session for specific course even there is a global option enabled which restrict students marking within session time.