### PR TITLE
Fix file retrieval condition in lib.php

### DIFF
--- a/classes/courseformat/overview.php
+++ b/classes/courseformat/overview.php
@@ -55,7 +55,7 @@ class overview extends \core_courseformat\activityoverviewbase {
         $content = new action_link(
             url: $url,
             text: $text,
-            attributes: ['class' => button::BODY_OUTLINE->classes()],
+            attributes: ['class' => "btn btn-outline-secondary"],
         );
 
         return new overviewitem(

--- a/lib.php
+++ b/lib.php
@@ -474,7 +474,8 @@ function attendance_pluginfile($course, $cm, $context, $filearea, $args, $forced
     $fs = get_file_storage();
     $relativepath = implode('/', $args);
     $fullpath = "/$context->id/mod_attendance/$filearea/$sessid/$relativepath";
-    if (!$file = $fs->get_file_by_hash(sha1($fullpath)) || $file->is_directory()) {
+    $file = $fs->get_file_by_hash(sha1($fullpath));
+    if (!$file || $file->is_directory()) {
         return false;
     }
     send_stored_file($file, 0, 0, true);


### PR DESCRIPTION
the multimedia inserted into description, they cannot be displayed with error "The media could not be loaded, either because the server or network failed or because the format is not supported."