### PR TITLE
Fix access control in update_user_status

### DIFF
--- a/externallib.php
+++ b/externallib.php
@@ -549,6 +549,11 @@ class mod_attendance_external extends external_api {
 
         // If not a teacher, make sure session is open for self-marking.
         if (!has_capability('mod/attendance:takeattendances', $context)) {
+            global $USER;
+            if ($params['studentid'] != $USER->id || $params['takenbyid'] != $USER->id) {
+                throw new invalid_parameter_exception('Invalid user id or no permissions.');
+            }
+
             [$canmark, $reason] = attendance_can_student_mark($session);
             if (!$canmark) {
                 throw new invalid_parameter_exception($reason);

--- a/tests/external/external_test.php
+++ b/tests/external/external_test.php
@@ -318,6 +318,52 @@ final class external_test extends externallib_advanced_testcase {
     }
 
     /**
+     * Test students cannot update attendance for another user via ws.
+     *
+     * @covers \mod_attendance\external::update_user_status
+     * @return void
+     * @throws \invalid_parameter_exception
+     */
+    public function test_update_user_status_disallows_other_students(): void {
+        global $DB;
+
+        $this->resetAfterTest(true);
+        set_config('studentscanmark', 1, 'attendance');
+
+        $courseswithsessions = attendance_handler::get_courses_with_today_sessions($this->teacher->id);
+        $courseswithsessions = external_api::clean_returnvalue(
+            mod_attendance_external::get_courses_with_today_sessions_returns(),
+            $courseswithsessions
+        );
+
+        $course = array_pop($courseswithsessions);
+        $attendanceinstance = array_pop($course['attendance_instances']);
+        $session = array_pop($attendanceinstance['today_sessions']);
+        $DB->set_field('attendance_sessions', 'studentscanmark', 1, ['id' => $session['id']]);
+
+        $sessioninfo = attendance_handler::get_session($session['id']);
+        $sessioninfo = external_api::clean_returnvalue(
+            mod_attendance_external::get_session_returns(),
+            $sessioninfo
+        );
+
+        $status = array_pop($sessioninfo['statuses']);
+        $statusset = $sessioninfo['statusset'];
+        $attacker = $this->students[0];
+        $victim = $this->students[1];
+
+        $this->setUser($attacker);
+        $this->expectException('invalid_parameter_exception');
+        mod_attendance_external::update_user_status(
+            $session['id'],
+            $victim->id,
+            $victim->id,
+            $status['id'],
+            $statusset
+        );
+    }
+
+    /**
      * Test adding new attendance record via ws.
      *
      * @covers \mod_attendance\external::add_attendance


### PR DESCRIPTION
The `update_user_status external` function let any authenticated user with `mod/attendance:view` mark attendance for another student, as long as the session allowed student self-marking. 
The capability check only gated teacher-style access; it didn't verify that a self-marking student was acting on their own record.

Changes:
externallib.php: require non-teacher callers to use their own studentid and takenbyid before allowing self-marking.

external_test.php: add a regression test that a student cannot mark another student via the web service.