### PR TITLE
Adding courseinfo to QR Code screen and devcontainer build setup

### DIFF
--- a/classes/calendar_helpers.php
+++ b/classes/calendar_helpers.php
@@ -24,7 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once(dirname(__FILE__) . '/../../../calendar/lib.php');
+require_once($CFG->dirroot . '/calendar/lib.php');
+require_once(dirname(__FILE__) . '/../lib.php');
 
 /**
  * Create single calendar event bases on session data.

--- a/password.php
+++ b/password.php
@@ -56,6 +56,15 @@ $PAGE->set_title(get_string('password', 'attendance'));
 
 echo $OUTPUT->header();
 
+// Display course and session information to help teachers identify the active session.
+$course = get_course($cm->course);
+echo html_writer::tag('h2', 
+    html_writer::tag( 'strong', format_string($course->fullname, true, array('context' => $context)))
+);
+echo html_writer::tag('h3', 
+    html_writer::tag( 'strong', userdate($session->sessdate))
+);
+
 $showpassword = (isset($session->studentpassword) && strlen($session->studentpassword) > 0);
 $showqr = (isset($session->includeqrcode) && $session->includeqrcode == 1);
 $rotateqr = (isset($session->rotateqrcode) && $session->rotateqrcode == 1);
@@ -65,9 +74,9 @@ if ($rotateqr) {
 
 if ($showpassword) {
     if ($showqr) {
-        echo html_writer::div("<h2>" . get_string('qrcodeandpasswordheader', 'attendance'), 'qrcodeheader') . "</h2>";
+        echo html_writer::div( get_string('qrcodeandpasswordheader', 'attendance'), 'qrcodeheader') ;
     } else {
-        echo html_writer::div("<h2>" . get_string('passwordheader', 'attendance'), 'qrcodeheader') . "</h2>";
+        echo html_writer::div( get_string('passwordheader', 'attendance'), 'qrcodeheader') ;
     }
     echo html_writer::span($session->studentpassword, 'student-password');
     echo html_writer::div('&nbsp;');

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2025122100;
+$plugin->version  = 2026042101;
 $plugin->release = 2025111100;
 $plugin->requires = 2025031100; // Requires 5.0.
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
This should satisfy #857 .
Full disclosure, I used copilot to help as I was struggling to get the dev environment set up. Therefore, in addition to the small addition to the QR Code screen, we also have. devcontainer setup that's been debugged and verified to work on my M1 mac using vscode. If you have the extension installed, it will build the moodle environment and launch it upon 'reopen in dev container.' There's also a script in the `/scripts` folder to create a course with a few students and an attendance. That way I was able to launch and test everything pretty quickly.

I fiddled a bit with the layout to find something that I like, but it might break some style rules and it's easy enough to change if needed. I suspect most people won't like it as is. Happy to help if so, but this is at least functional.

Finally, not sure the policy on version bumps, but I tried to update it appropriately.