### PR TITLE
Add Moodle Playground preview blueprint and PR action

### DIFF
--- a/.github/workflows/pr-playground-preview.yml
+++ b/.github/workflows/pr-playground-preview.yml
@@ -1,0 +1,30 @@
+---
+name: PR Playground Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+concurrency:
+  group: playground-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  playground-preview:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: ateeducacion/action-moodle-playground-pr-preview@main
+        with:
+          blueprint-file: blueprint.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          moodle-version: '5.1'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # ABOUT
 
+## Try in Moodle Playground
+
+Click the badge below to open the `MOODLE_501_STABLE` branch instantly in [Moodle Playground](https://moodle-playground.com) with `mod_attendance` pre-installed. The playground boots a full Moodle 5.1 site with a demo course (`ATTDEMO01`) containing a preloaded attendance activity, so you can add sessions and try the attendance workflow without any local setup. Every same-repo pull request also automatically generates a playground preview link appended to the PR description so reviewers can test changes in a live Moodle instance.
+
+<a href="https://moodle-playground.com/?blueprint-url=https://raw.githubusercontent.com/danmarsden/moodle-mod_attendance/refs/heads/MOODLE_501_STABLE/blueprint.json" target="_blank" rel="noopener"><img src="https://raw.githubusercontent.com/ateeducacion/action-moodle-playground-pr-preview/refs/heads/main/assets/playground-preview-button.svg" alt="Preview in Moodle Playground" width="200"></a>
+
+The PR preview links are produced by the [ateeducacion/action-moodle-playground-pr-preview](https://github.com/ateeducacion/action-moodle-playground-pr-preview) GitHub Action, configured via `blueprint.json` at the repository root.
+
 The Attendance module is supported and maintained by Dan Marsden http://danmarsden.com
 
 The Attendance module was previously developed by

--- a/blueprint.json
+++ b/blueprint.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ateeducacion/moodle-playground/refs/heads/main/assets/blueprints/blueprint-schema.json",
+  "preferredVersions": {
+    "php": "8.3",
+    "moodle": "5.1"
+  },
+  "landingPage": "/course/view.php?id=2",
+  "constants": {
+    "ADMIN_USER": "admin",
+    "ADMIN_PASS": "test",
+    "ADMIN_EMAIL": "admin@example.com"
+  },
+  "steps": [
+    {
+      "step": "installMoodle",
+      "options": {
+        "adminUser": "{{ADMIN_USER}}",
+        "adminPass": "{{ADMIN_PASS}}",
+        "adminEmail": "{{ADMIN_EMAIL}}",
+        "siteName": "Attendance Activity Demo",
+        "locale": "en",
+        "timezone": "Europe/Madrid"
+      }
+    },
+    {
+      "step": "login",
+      "username": "{{ADMIN_USER}}"
+    },
+    {
+      "step": "installMoodlePlugin",
+      "pluginType": "mod",
+      "pluginName": "attendance",
+      "url": "https://github.com/danmarsden/moodle-mod_attendance/archive/refs/heads/MOODLE_501_STABLE.zip"
+    },
+    {
+      "step": "createCategory",
+      "name": "Test Courses"
+    },
+    {
+      "step": "createCourse",
+      "fullname": "Attendance Activity Demo Course",
+      "shortname": "ATTDEMO01",
+      "category": "Test Courses",
+      "summary": "Demo course for the mod_attendance activity module. A sample attendance instance is preloaded so you can immediately add sessions and try the attendance taking workflow.",
+      "format": "topics",
+      "numsections": 3
+    },
+    {
+      "step": "createUser",
+      "username": "student",
+      "password": "test",
+      "email": "student@example.com",
+      "firstname": "Demo",
+      "lastname": "Student"
+    },
+    {
+      "step": "enrolUser",
+      "username": "{{ADMIN_USER}}",
+      "course": "ATTDEMO01",
+      "role": "editingteacher"
+    },
+    {
+      "step": "enrolUser",
+      "username": "student",
+      "course": "ATTDEMO01",
+      "role": "student"
+    },
+    {
+      "step": "runPhpCode",
+      "code": "if (!defined('CLI_SCRIPT')) { define('CLI_SCRIPT', true); }\nrequire('/www/moodle/config.php');\nrequire_once($CFG->dirroot . '/course/lib.php');\nrequire_once($CFG->dirroot . '/mod/attendance/lib.php');\ntry {\n    $course = $DB->get_record('course', ['shortname' => 'ATTDEMO01'], '*', MUST_EXIST);\n    $module = $DB->get_record('modules', ['name' => 'attendance'], '*', MUST_EXIST);\n    $admin = get_admin();\n    \\core\\session\\manager::set_user($admin);\n    $now = time();\n    $cm = (object)[\n        'course'       => $course->id,\n        'module'       => $module->id,\n        'instance'     => 0,\n        'section'      => 1,\n        'idnumber'     => '',\n        'added'        => $now,\n        'score'        => 0,\n        'indent'       => 0,\n        'visible'      => 1,\n        'visibleold'   => 1,\n        'groupmode'    => 0,\n        'groupingid'   => 0,\n        'completion'   => 0,\n        'showdescription' => 0,\n    ];\n    $cmid = add_course_module($cm);\n    $attendance = (object)[\n        'course'       => $course->id,\n        'coursemodule' => $cmid,\n        'name'         => 'Sample attendance register',\n        'intro'        => '<p>Open this attendance activity to try the <strong>mod_attendance</strong> workflow: add sessions, take attendance for the demo student, and explore the reports tab.</p>',\n        'introformat'  => FORMAT_HTML,\n        'grade'        => 100,\n        'subnet'       => '',\n        'sessiondetailspos' => 'left',\n        'showsessiondescriptiononreport' => 0,\n    ];\n    $instanceid = attendance_add_instance($attendance);\n    $DB->set_field('course_modules', 'instance', $instanceid, ['id' => $cmid]);\n    course_add_cm_to_section($course->id, $cmid, 1);\n    rebuild_course_cache($course->id, true);\n    echo \"Created mod_attendance instance id={$instanceid} cmid={$cmid} in course {$course->shortname}\\n\";\n} catch (\\Throwable $e) {\n    echo 'ERROR: ' . $e->getMessage() . \"\\n\";\n}"
+    },
+    {
+      "step": "setLandingPage",
+      "path": "/course/view.php?id=2"
+    }
+  ]
+}

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2026042100;
+$plugin->version  = 2026042101;
 $plugin->release = 2026042100;
 $plugin->requires = 2025100600; // Requires 5.1.
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
## About this PR — Moodle Playground

[Moodle Playground](https://moodle-playground.com) (source: [ateeducacion/moodle-playground](https://github.com/ateeducacion/moodle-playground)) is a project that runs a full Moodle site **entirely inside the browser** (PHP + SQLite compiled to WebAssembly), with no server, no Docker and no local install. Given a `blueprint.json` it provisions a fresh Moodle instance, installs plugins, creates users / courses / sample content, and opens on a chosen landing page.

This PR wires that up for `mod_attendance` so contributors and reviewers can **try and test the plugin in a real Moodle instance with one click** — useful both for users who just want to evaluate it and for reviewers who want to validate a change without standing up a local Moodle.

> ℹ️ **Live PR-preview demo:** see the same change applied on my fork at https://github.com/erseco/moodle-mod_attendance/pull/1 — once the workflow finishes, that PR's description gets a "Preview in Moodle Playground" button appended automatically. That is exactly what every future PR opened against this repo will look like once this is merged.

## Summary
- Adds `blueprint.json` describing a Moodle 5.1 demo site that installs `mod_attendance` from this branch (`installMoodlePlugin`), creates a demo course (`ATTDEMO01`) and preloads a sample attendance activity via a `runPhpCode` step that calls `attendance_add_instance()` directly (same pattern used in [`projectestac/moodle-mod_geogebra`](https://github.com/projectestac/moodle-mod_geogebra)'s blueprint). `mod_attendance` is fully self-contained — no external API or workaround required.
- Adds `.github/workflows/pr-playground-preview.yml` which uses [`ateeducacion/action-moodle-playground-pr-preview`](https://github.com/ateeducacion/action-moodle-playground-pr-preview) to publish a live Moodle Playground preview link on every same-repo PR.
- Adds a "Try in Moodle Playground" section + badge to `README.md` linking to the blueprint.